### PR TITLE
fix: swagger 오류 해결 및 grantType 설정 누락 수정 

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/global/config/SwaggerConfig.java
+++ b/src/main/java/BE_Elixir/Elixir/global/config/SwaggerConfig.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Configuration
 @SecurityScheme(
-        name = "Authorization",
+        name = "bearerAuth",
         type = SecuritySchemeType.HTTP,
         scheme = "bearer",
         bearerFormat = "JWT"

--- a/src/main/java/BE_Elixir/Elixir/global/security/JwtProvider.java
+++ b/src/main/java/BE_Elixir/Elixir/global/security/JwtProvider.java
@@ -101,6 +101,7 @@ public class JwtProvider {
         log.info("새로운 Access Token 발급: {}", newAccessToken);
 
         return TokenResponseDTO.builder()
+                .grantType("Bearer")
                 .accessToken(newAccessToken)
                 .refreshToken(refreshToken)  // 기존 거 그대로 반환
                 .build();


### PR DESCRIPTION
## 📌 Issue Number
- close https://github.com/SWU-Elixir/Backend/issues/2

## 🪐 작업 내용
- Access Token 재발급 시 grantType 값 누락된 것 해결
- swagger 에서 Security Schema name 불일치로 ui에서 잘 작동하지 않은 문제 해결

## ✅ PR 상세 내용
- generateAccessTokenToken() 에서 DTO 빌드 시에 grantType 설정 추가
- Security Schema name 통일

## 📚 Reference
- X