### PR TITLE
fix: refresh 기능 오류 해결, feat: properties에 whitelist 추가, docs: swagger 수정

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/auth/controller/AuthController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/controller/AuthController.java
@@ -62,7 +62,7 @@ public class AuthController implements AuthApi {
             authService.logout(email, accessToken, refreshToken);
             log.info("로그아웃 성공 - email: {}", email);
 
-            return ResponseEntity.ok(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),"로그아웃 성공", null));
+            return ResponseEntity.ok(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),"로그아웃 성공"));
         } catch (Exception e) {
             log.warn("로그아웃 실패 - email: {}, message: {}", email, e.getMessage());
             return ResponseEntity
@@ -74,7 +74,7 @@ public class AuthController implements AuthApi {
 
     // Access Token 재발급
     @PostMapping("/refresh")
-    public ResponseEntity<CommonResponse<TokenResponseDTO>> refresh (
+    public ResponseEntity<CommonResponse<AccessTokenDTO>> refresh (
             @AuthenticationPrincipal MemberDetails memberDetails,
             HttpServletRequest request
     ) {
@@ -86,7 +86,9 @@ public class AuthController implements AuthApi {
             AccessTokenDTO token = authService.refreshAccessToken(email, refreshToken);
 
             log.info("Access Token 재발급 성공 - email: {}", email);
-            return ResponseEntity.ok(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(), "Access Token 재발급 성공", token));
+            return ResponseEntity.ok(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "Access Token 재발급 성공", token));
+
         } catch (Exception e) {
             log.warn("Access Token 재발급 실패 - email: {}, message: {}", email, e.getMessage());
             return ResponseEntity

--- a/src/main/java/BE_Elixir/Elixir/domain/auth/controller/AuthController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package BE_Elixir.Elixir.domain.auth.controller;
 
 import BE_Elixir.Elixir.domain.auth.controller.api.AuthApi;
+import BE_Elixir.Elixir.domain.auth.dto.AccessTokenDTO;
 import BE_Elixir.Elixir.domain.auth.service.AuthService;
 import BE_Elixir.Elixir.domain.auth.dto.response.TokenResponseDTO;
 import BE_Elixir.Elixir.domain.auth.dto.request.LoginRequestDTO;
@@ -82,7 +83,7 @@ public class AuthController implements AuthApi {
 
         try {
             String refreshToken = redisService.getRefreshToken(email);
-            TokenResponseDTO token = jwtProvider.refreshAccessToken(email, refreshToken);
+            AccessTokenDTO token = authService.refreshAccessToken(email, refreshToken);
 
             log.info("Access Token 재발급 성공 - email: {}", email);
             return ResponseEntity.ok(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(), "Access Token 재발급 성공", token));

--- a/src/main/java/BE_Elixir/Elixir/domain/auth/controller/api/AuthApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/controller/api/AuthApi.java
@@ -1,5 +1,6 @@
 package BE_Elixir.Elixir.domain.auth.controller.api;
 
+import BE_Elixir.Elixir.domain.auth.dto.AccessTokenDTO;
 import BE_Elixir.Elixir.domain.auth.dto.response.TokenResponseDTO;
 import BE_Elixir.Elixir.domain.auth.dto.request.LoginRequestDTO;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
@@ -21,33 +22,59 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "Auth API", description = "회원 인증 관련 API")
 public interface AuthApi {
 
-    @Operation(summary = "로그인", description = "로그인합니다.")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다..")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공",
-                    content = @Content(schema = @Schema(implementation = TokenResponseDTO.class),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "grantType": "bearer",
-                                      "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                                      "refreshToken": "dGhpc2lzYXJlZnJlc2h0b2tlbg=="
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인 성공",
+                                      "data": {
+                                        "grantType": "bearer",
+                                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                                        "refreshToken": "dGhpc2lzYXJlZnJlc2h0b2tlbg=="
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "401", description = "로그인 실패",
-                    content = @Content(schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "로그인 실패: 이메일 또는 비밀번호가 일치하지 않습니다.")))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 UNAUTHORIZED",
+                                      "message": "로그인 실패 - 아이디 또는 비밀번호가 일치하지 않습니다.",
+                                      "data": null
+                                    }
+                                    """)))
     })
     ResponseEntity<CommonResponse<TokenResponseDTO>> login(@RequestBody LoginRequestDTO request);
 
     @Operation(summary = "로그아웃",
-            description = "로그아웃합니다.",
+            description = "현재 로그인된 회원을 로그아웃합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그아웃 성공",
-                    content = @Content(schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "로그아웃 성공"))),
-            @ApiResponse(responseCode = "400", description = "로그아웃 실패",
-                    content = @Content(schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "로그아웃 실패: 이미 만료된 토큰입니다.")))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                    examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그아웃 성공",
+                                      "data": null
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "로그아웃 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 BAD_REQUEST",
+                                      "message": "로그아웃 실패 - 유효하지 않거나 만료된 Refresh Token",
+                                      "data": null
+                                    }
+                                    """))),
     })
     ResponseEntity<CommonResponse<?>> logout(
             @AuthenticationPrincipal MemberDetails memberDetails,
@@ -55,23 +82,33 @@ public interface AuthApi {
     );
 
     @Operation(summary = "토큰 재발급",
-            description = "Access Token, Refresh Token을 재발급합니다.",
+            description = "유효한 Refresh Token을 이용해 Access Token을 재발급합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Access Token 재발급 성공",
-                    content = @Content(schema = @Schema(implementation = TokenResponseDTO.class),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "grantType": "bearer",
-                                      "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                                      "refreshToken": "dGhpc2lzYXJlZnJlc2h0b2tlbg=="
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "Access Token 재발급 성공",
+                                      "data": {
+                                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "401", description = "Access Token 재발급 실패",
-                    content = @Content(schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Access Token 재발급 실패: 유효하지 않은 Refresh Token입니다.")))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 UNAUTHORIZED",
+                                      "message": "Access Token 재발급 실패 - Access Token 재발급 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
     })
-    ResponseEntity<CommonResponse<TokenResponseDTO>> refresh (
+    ResponseEntity<CommonResponse<AccessTokenDTO>> refresh (
             @AuthenticationPrincipal MemberDetails memberDetails,
             HttpServletRequest request
     );

--- a/src/main/java/BE_Elixir/Elixir/domain/auth/dto/AccessTokenDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/dto/AccessTokenDTO.java
@@ -1,0 +1,12 @@
+package BE_Elixir.Elixir.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class AccessTokenDTO {
+    private String accessToken;
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
@@ -1,7 +1,10 @@
 package BE_Elixir.Elixir.domain.auth.service;
 
+import BE_Elixir.Elixir.domain.auth.dto.AccessTokenDTO;
 import BE_Elixir.Elixir.domain.auth.dto.response.TokenResponseDTO;
 import BE_Elixir.Elixir.domain.auth.dto.request.LoginRequestDTO;
+import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
+import BE_Elixir.Elixir.domain.member.service.MemberDetailsService;
 import BE_Elixir.Elixir.global.redis.RedisService;
 import BE_Elixir.Elixir.global.security.JwtProvider;
 import jakarta.transaction.Transactional;
@@ -11,7 +14,6 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
 
 
@@ -24,6 +26,7 @@ public class AuthService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtProvider jwtProvider;
     private final RedisService redisService;
+    private final MemberDetailsService memberDetailsService;
 
     // 로그인 (jwt 발급 및 Redis 저장)
     public TokenResponseDTO signIn(LoginRequestDTO request) {
@@ -75,5 +78,19 @@ public class AuthService {
         } else {
             throw new RuntimeException("유효하지 않거나 만료된 Refresh Token");
         }
+    }
+
+    // Refresh Token을 이용해 새로운 Access Token, Refresh Token을 발급
+    public AccessTokenDTO refreshAccessToken(String email, String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new RuntimeException("Refresh Token 이 유효하지 않습니다.");
+        }
+
+        // 회원 인증 정보 츄츌
+        MemberDetails memberDetails = memberDetailsService.loadUserByUsername(email);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                email, "", memberDetails.getAuthorities());
+
+        return jwtProvider.generateAccessToken(authentication);
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 
@@ -30,8 +31,6 @@ public class AuthService {
 
     // 로그인 (jwt 발급 및 Redis 저장)
     public TokenResponseDTO signIn(LoginRequestDTO request) {
-        log.info("login");
-
         try {
             // email + password 기반 authentication 객체 생성
             UsernamePasswordAuthenticationToken authenticationToken =
@@ -82,15 +81,23 @@ public class AuthService {
 
     // Refresh Token을 이용해 새로운 Access Token, Refresh Token을 발급
     public AccessTokenDTO refreshAccessToken(String email, String refreshToken) {
-        if (!jwtProvider.validateToken(refreshToken)) {
-            throw new RuntimeException("Refresh Token 이 유효하지 않습니다.");
+        try {
+            if (!jwtProvider.validateToken(refreshToken)) {
+                throw new RuntimeException("유효하지 않은 Refresh Token");
+            }
+
+            // 회원 인증 정보 추출
+            MemberDetails memberDetails = memberDetailsService.loadUserByUsername(email);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    email, "", memberDetails.getAuthorities());
+
+            return jwtProvider.generateAccessToken(authentication);
+        } catch (UsernameNotFoundException e) {
+            throw new RuntimeException("찾을 수 없는 회원", e);
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("유효하지 않은 Refresh Token", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Access Token 재발급 중 오류가 발생했습니다.", e);
         }
-
-        // 회원 인증 정보 츄츌
-        MemberDetails memberDetails = memberDetailsService.loadUserByUsername(email);
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-                email, "", memberDetails.getAuthorities());
-
-        return jwtProvider.generateAccessToken(authentication);
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -44,7 +44,7 @@ public class MemberController implements MemberApi {
             Member member = memberService.signUp(request);
             log.info("회원가입 성공 - 회원 ID: {}", member.getId());
             return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(), "회원가입 성공 - member_id = " + member.getId(), null));
+                    .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(), "회원가입 성공 - memberId: " + member.getId()));
 
         } catch (Exception e) {
             log.error("회원가입 실패 - 이메일: {}, 메시지: {}", request.getEmail(), e.getMessage(), e);
@@ -61,14 +61,14 @@ public class MemberController implements MemberApi {
             HttpServletRequest request
     ) {
         String email = memberDetails.getUsername();
-        log.info("회원탈퇴 요청 - 이메일: {}", email);
+        log.info("회원탈퇴 요청 - email: {}", email);
 
         try {
             String accessToken = jwtProvider.resolveToken(request);
             String refreshToken = redisService.getRefreshToken(memberDetails.getUsername());
 
             memberService.withdraw(email, accessToken, refreshToken);
-            log.info("회원탈퇴 성공 - 이메일: {}", email);
+            log.info("회원탈퇴 성공 - email: {}", email);
 
             return ResponseEntity.ok(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(), "회원탈퇴 성공"));
 

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -6,6 +6,7 @@ import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -28,16 +29,40 @@ public interface MemberApi {
     // 반환 상태 코드 및 의미
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "중복 여부 조회 성공",
-                    content = @Content(schema = @Schema(implementation = Boolean.class)))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인 성공",
+                                      "data": true
+                                    }
+                                    """)))
     })
     ResponseEntity<Boolean> checkEmailDuplicate(@RequestParam String email);
 
     @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공",
-                    content = @Content(schema = @Schema(type = "string", example = "회원가입 성공 - member_id = 1"))),
-            @ApiResponse(responseCode = "400", description = "회원가입 실패",
-                    content = @Content(schema = @Schema(type = "string", example = "회원가입 실패: 이메일이 이미 존재합니다.")))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "회원가입 성공 - memberId: 1",
+                                      "data": null
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "회원가입 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                    examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 BAD_REQUEST",
+                                      "message": "회원가입 실패: 회원가입 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
     })
     ResponseEntity<CommonResponse<?>> signUp(@RequestBody SignUpRequestDTO request);
 
@@ -46,11 +71,25 @@ public interface MemberApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원탈퇴 성공",
-                    content = @Content(schema = @Schema(type = "string", example = "회원탈퇴 성공"))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청",
-                    content = @Content(schema = @Schema(type = "string", example = "요청이 잘못되었습니다."))),
-            @ApiResponse(responseCode = "500", description = "서버 오류",
-                    content = @Content(schema = @Schema(type = "string", example = "회원탈퇴 중 오류가 발생했습니다.")))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "회원탈퇴 성공 - email: example@naver.com",
+                                      "data": null
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "회원탈퇴 실패 - 유효하지 않거나 만료된 Refresh Token",
+                                      "data": null
+                                    }
+                                    """)))
     })
     ResponseEntity<CommonResponse<?>> withdrawal(
             @AuthenticationPrincipal MemberDetails memberDetails,

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberDetailsService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberDetailsService.java
@@ -1,14 +1,9 @@
 package BE_Elixir.Elixir.domain.member.service;
 
-import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -24,7 +19,7 @@ public class MemberDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    public MemberDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         log.info("회원 정보 로딩 시도: {}", email);
 
         return memberRepository.findByEmail(email)

--- a/src/main/java/BE_Elixir/Elixir/global/config/WhitelistProperties.java
+++ b/src/main/java/BE_Elixir/Elixir/global/config/WhitelistProperties.java
@@ -1,0 +1,16 @@
+package BE_Elixir.Elixir.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "security")
+public class WhitelistProperties {
+    private String[] whitelist;
+}

--- a/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
@@ -8,8 +8,6 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "인증이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN.value(), "접근이 거부되었습니다."),
     EXISTS_MEMBER(HttpStatus.CONFLICT.value(), "이미 존재하는 회원입니다.");
 
     private final int status;

--- a/src/main/java/BE_Elixir/Elixir/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/BE_Elixir/Elixir/global/security/JwtAuthenticationFilter.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        // 1. Request Header 에서 JWT 토큰 추출
+        // 1. Request Header 에서 JWT 토큰(Access Token) 추출
         String token = resolveToken((HttpServletRequest) request);
 
         if (token == null) {
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             log.warn("유효하지 않거나 만료된 JWT 토큰이 요청에 포함되어 있습니다.");
         }
 
-        // 2. validationToken으로 토큰 유효성 검사
+        // 2. validationToken()으로 토큰 유효성 검사
         if (token != null && jwtProvider.validateToken(token)) {
             try {
                 // 토큰이 유효할 경우 토큰에서 Authentication 객체를 갖고 와서 SecurityContext에 저장

--- a/src/main/java/BE_Elixir/Elixir/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/BE_Elixir/Elixir/global/security/JwtAuthenticationFilter.java
@@ -9,10 +9,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
+import java.util.List;
 
 // jwt 인증을 위한 커스텀 필터
 @Slf4j
@@ -20,9 +22,22 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtProvider jwtProvider;
+    private final String[] whitelist;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String requestURI = httpRequest.getRequestURI();
+
+        // 허용 경로는 필터 건너뛰기
+        for (String pattern : whitelist) {
+            if (pathMatcher.match(pattern, requestURI)) {
+                chain.doFilter(request, response);
+                return;
+            }
+        }
+
         // 1. Request Header 에서 JWT 토큰(Access Token) 추출
         String token = resolveToken((HttpServletRequest) request);
 

--- a/src/main/java/BE_Elixir/Elixir/global/security/JwtProvider.java
+++ b/src/main/java/BE_Elixir/Elixir/global/security/JwtProvider.java
@@ -116,7 +116,7 @@ public class JwtProvider {
 
         String email = claims.getSubject();
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다. 이메일: " + email));
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다. email: " + email));
 
         MemberDetails principal = new MemberDetails(member);
 

--- a/src/main/java/BE_Elixir/Elixir/global/security/JwtProvider.java
+++ b/src/main/java/BE_Elixir/Elixir/global/security/JwtProvider.java
@@ -1,5 +1,6 @@
 package BE_Elixir.Elixir.global.security;
 
+import BE_Elixir.Elixir.domain.auth.dto.AccessTokenDTO;
 import BE_Elixir.Elixir.domain.auth.dto.response.TokenResponseDTO;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
@@ -65,10 +66,14 @@ public class JwtProvider {
     }
 
     // 인증 정보 기반 Access Token 발급 (토큰 재발급 시)
-    public String generateAccessTokenToken(Authentication authentication) {
+    public AccessTokenDTO generateAccessToken(Authentication authentication) {
         String authorities = getAuthorities(authentication);
         long now = System.currentTimeMillis();
-        return createAccessToken(authentication.getName(), authorities, now);
+        String accessToken = createAccessToken(authentication.getName(), authorities, now);
+
+        return AccessTokenDTO.builder()
+                .accessToken(accessToken)
+                .build();
     }
 
     // 인증 정보 기반 Access Token + Refresh Token 발급 (로그인 시)
@@ -83,27 +88,6 @@ public class JwtProvider {
                 .grantType("Bearer")
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .build();
-    }
-
-    // Refresh Token을 이용해 새로운 Access Token, Refresh Token을 발급
-    public TokenResponseDTO refreshAccessToken(String email, String refreshToken) {
-        if (!validateToken(refreshToken)) {
-            throw new RuntimeException("Refresh Token 이 유효하지 않습니다.");
-        }
-
-        Claims claims = parseClaims(refreshToken);
-        String username = claims.getSubject();
-        Authentication authentication = new UsernamePasswordAuthenticationToken(username, "", null);
-
-        String newAccessToken = generateAccessTokenToken(authentication);
-
-        log.info("새로운 Access Token 발급: {}", newAccessToken);
-
-        return TokenResponseDTO.builder()
-                .grantType("Bearer")
-                .accessToken(newAccessToken)
-                .refreshToken(refreshToken)  // 기존 거 그대로 반환
                 .build();
     }
 

--- a/src/main/java/BE_Elixir/Elixir/global/security/SecurityConfig.java
+++ b/src/main/java/BE_Elixir/Elixir/global/security/SecurityConfig.java
@@ -1,6 +1,6 @@
 package BE_Elixir.Elixir.global.security;
 
-import BE_Elixir.Elixir.global.exception.ErrorCode;
+import BE_Elixir.Elixir.global.config.WhitelistProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,7 +21,6 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.io.PrintWriter;
-import java.nio.file.AccessDeniedException;
 
 @Configuration
 @EnableWebSecurity
@@ -30,22 +29,14 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
 
+    // 권한 확인을 하지 않는 url
+    private final WhitelistProperties whitelistProperties;
+
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
-    // 권한 확인을 하지 않는 url
-    private static final String[] PERMIT_ALL_PATTERNS = new String[] {
-            "/test",
-            "/swagger-ui/*",
-            "/swagger-ui.html",
-            "/swagger-ui/**",
-            "/api-docs/**",
-            "/api/member/check-email",
-            "/api/member/signup",
-            "/api/auth/login"
-    };
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {
@@ -70,10 +61,11 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // 검사하지 않는 url
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(PERMIT_ALL_PATTERNS).permitAll()
+                        .requestMatchers(whitelistProperties.getWhitelist()).permitAll()
                         .anyRequest().authenticated())
                 // jwt 인증을 위해 직접 구현한 필터
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, whitelistProperties.getWhitelist()),
+                        UsernamePasswordAuthenticationFilter.class)
 
                 .exceptionHandling((exceptionConfig) ->
                         exceptionConfig.authenticationEntryPoint(unauthorizedEntryPoint).accessDeniedHandler(accessDeniedHandler)
@@ -84,7 +76,7 @@ public class SecurityConfig {
     private final AuthenticationEntryPoint unauthorizedEntryPoint =
             ((request, response, authException) -> {
                 response.setStatus(HttpStatus.UNAUTHORIZED.value());
-                String json = new ObjectMapper().writeValueAsString(ErrorCode.UNAUTHORIZED);
+                String json = new ObjectMapper().writeValueAsString(HttpStatus.UNAUTHORIZED);
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 PrintWriter writer = response.getWriter();
                 writer.write(json);
@@ -95,7 +87,7 @@ public class SecurityConfig {
     private final AccessDeniedHandler accessDeniedHandler =
             ((request, response, accessDeniedException) -> {
                 response.setStatus(HttpStatus.FORBIDDEN.value());
-                String json = new ObjectMapper().writeValueAsString(ErrorCode.FORBIDDEN);
+                String json = new ObjectMapper().writeValueAsString(HttpStatus.FORBIDDEN);
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 PrintWriter writer = response.getWriter();
                 writer.write(json);


### PR DESCRIPTION
> 수정 내용 별로 따로 올렸어야 했는데.. 다음부터는 조심하겠습니다 😂


## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/2

## 🪐 작업 내용
- Access Token 재발급 기능(refresh) 인증 문제 해결
- 인증 필요 없는 요청 패턴을 설정 파일(properties)에서 관리하고, whitelist로 받아와 사용할 수 있도록 수정
    - 인증이 필요 없는 패턴에서도 JwtCustomFilter가 계속 작동하면서 의미없는 log가 쌓이는 문제
    - JwtCustomFilter에서 요청 uri를 보고 인증이 불필요한 경우 다음 필터로 넘기도록 적용해야 했음
    - 기존에 인증 필요 없는 요청 패턴은 securityConfig에서 상수 변수로 관리했으나 두 클래스에서 함께 사용할 필요가 있기 때문에 설정 파일에서 갖고 오는 방식 채택
- response 형식 통일 등 수정된 내용에 대해 swagger ui 수정

## ✅ PR 상세 내용
- Access Token 재발급 기능(refresh) 인증 문제 해결
    - 인증 객체 생성 시 권한이 null이었던 문제 발견 -> memberDetails 에서 권한을 가져오도록 수정
    - Access Token만 반환하도록 수정
    - 예외 처리 추가
    - 기존에 JwtProvider 클래스에 있던 메소드를 AuthService로 이동
- 인증 필요 없는 요청 패턴을 설정 파일(properties)에서 관리하고, whitelist로 받아와 사용할 수 있도록 수정
    -  WhitelistProperties 클래스를 global/config에 추가해 properties에서 값을 받아와 배열로 저장하도록 설정
    - SecurityConfig, JwtCustomFilter에서 WhitelistProperties 를 활용해 whitelist를 가져와 각각 목적에 따라 활용
- response 형식 통일 등 수정된 내용에 대해 swagger ui 수정 

## 📚 Reference
- X