### PR TITLE
feat: 회원 정보 조회 기능 추가

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package BE_Elixir.Elixir.domain.member.controller;
 
 import BE_Elixir.Elixir.domain.member.controller.api.MemberApi;
 import BE_Elixir.Elixir.domain.member.dto.request.SignUpRequestDTO;
+import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.domain.member.service.MemberService;
@@ -82,6 +83,30 @@ public class MemberController implements MemberApi {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
                             "회원탈퇴 실패 - " + e.getMessage()));
+        }
+    }
+
+    // 회원 정보 조회 (이메일, 닉네임, 젠더, 생년, 프로필 url)
+    @GetMapping("")
+    public ResponseEntity<CommonResponse<MemberResponseDTO>> getMemberInfo(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            HttpServletRequest request)
+    {
+        String email = memberDetails.getUsername();
+        log.info("회원 정보 조회 요청 - email: {}", email);
+
+        try {
+            MemberResponseDTO response = memberService.getMemberInfo(email);
+            log.info("회원 정보 조회 성공 - email: {}", email);
+
+            return ResponseEntity.ok(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(), "회원조회 성공", response));
+
+        } catch (Exception e) {
+            log.warn("회원 정보 조회 실패 - email: {}, message: {}", email, e.getMessage());
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "회원 정보 조회 실패 - " + e.getMessage()));
         }
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -1,7 +1,7 @@
 package BE_Elixir.Elixir.domain.member.controller.api;
 
-import BE_Elixir.Elixir.domain.auth.dto.request.TokenRequestDTO;
-import BE_Elixir.Elixir.domain.member.dto.SignUpRequestDTO;
+import BE_Elixir.Elixir.domain.member.dto.request.SignUpRequestDTO;
+import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Tag(name = "Member API", description = "회원 관련 API")
@@ -64,7 +66,10 @@ public interface MemberApi {
                                     }
                                     """)))
     })
-    ResponseEntity<CommonResponse<?>> signUp(@RequestBody SignUpRequestDTO request);
+    ResponseEntity<CommonResponse<?>> signUp(
+            @RequestPart("dto") SignUpRequestDTO dto,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    );
 
     @Operation(summary = "회원탈퇴",
             description = "회원 정보를 삭제합니다.",

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -95,4 +95,42 @@ public interface MemberApi {
             @AuthenticationPrincipal MemberDetails memberDetails,
             HttpServletRequest request
     );
+
+
+    @Operation(summary = "회원 정보 조회",
+            description = "회원의 기본적인 정보(id, 이메일, 닉네임, 젠더, 생년)를 조회합니다",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "회원 정보 조회 성공",
+                                      "data": {
+                                        "id": 1,
+                                        "email": "example@naver.com",
+                                        "nickname": "example",
+                                        "gender": "female",
+                                        "birthYear": 2002,
+                                        "profileUrl": "https://s3elixir.s3..."
+                                      }
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "회원 정보 조회 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "회원 정보 조회 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<MemberResponseDTO>> getMemberInfo(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            HttpServletRequest request
+    );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/dto/request/SignUpRequestDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/dto/request/SignUpRequestDTO.java
@@ -1,4 +1,4 @@
-package BE_Elixir.Elixir.domain.member.dto;
+package BE_Elixir.Elixir.domain.member.dto.request;
 
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import lombok.*;

--- a/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberResponseDTO.java
@@ -1,0 +1,19 @@
+package BE_Elixir.Elixir.domain.member.dto.response;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberResponseDTO {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String gender;
+    private Integer birthYear;
+    private String profileUrl;
+
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package BE_Elixir.Elixir.domain.member.service;
 
 import BE_Elixir.Elixir.domain.member.dto.request.SignUpRequestDTO;
+import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.repository.MemberRepository;
 import BE_Elixir.Elixir.global.exception.ErrorCode;
@@ -115,6 +116,23 @@ public class MemberService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다. email: " + email));
         memberRepository.delete(member);
+    }
+
+
+    // 회원 정보 조회
+    public MemberResponseDTO getMemberInfo(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다. email: " + email));
+
+        // member 객체를 MemberResponseDTO 로 변환
+        return MemberResponseDTO.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .gender(member.getGender())
+                .birthYear(member.getBirthYear())
+                .profileUrl(member.getProfileUrl())
+                .build();
     }
 
 


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/6

## 🪐 작업 내용
- 회원 정보 조회 기능 추가

## ✅ PR 상세 내용
- 회원의 기본적인 정보(id, 이메일, 닉네임, 젠더, 생년)를 조회하는 기능 개발
- member 도메인 내 dto 폴더에서 request, response 폴더 분리

## 📚 Reference
- X