### PR TITLE
feat:swagger ui에 multipart/form-data 형태로 입력할 수 있게 설정

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -40,7 +41,7 @@ public class MemberController implements MemberApi {
     }
 
     // 회원가입
-    @PostMapping("/signup")
+    @PostMapping(value= "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CommonResponse<?>> signUp(
             @RequestPart("dto") SignUpRequestDTO dto,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage

--- a/src/main/java/BE_Elixir/Elixir/global/config/OctetStreamReadMsgConverter.java
+++ b/src/main/java/BE_Elixir/Elixir/global/config/OctetStreamReadMsgConverter.java
@@ -1,0 +1,34 @@
+package BE_Elixir.Elixir.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConverter {
+    @Autowired
+    public OctetStreamReadMsgConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    // 기존 application/octet-stream 타입을 쓰기로 다루는 메시지 컨버터가 이미 존재 (ByteArrayHttpMessageConverter)
+    // 따라서 해당 컨버터는 쓰기 작업에는 이용하면 안됨
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/BE_Elixir/Elixir/global/config/WebConfig.java
+++ b/src/main/java/BE_Elixir/Elixir/global/config/WebConfig.java
@@ -1,0 +1,23 @@
+package BE_Elixir.Elixir.global.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+
+    @Autowired
+    public WebConfig(OctetStreamReadMsgConverter octetStreamReadMsgConverter) {
+        this.octetStreamReadMsgConverter = octetStreamReadMsgConverter;
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(octetStreamReadMsgConverter);
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/17

## 🪐 작업 내용
- swagger ui에서 context type을 multipart/form-data 형태로 입력할 수 있게 설정
- application/octet-stream 처리를 위한 Message Converter 추가

## ✅ PR 상세 내용
- swagger ui에서 context type을 multipart/form-data 형태로 입력할 수 있게 설정
    - controller에서 `@PostMapping` 어노테이션 파라미터로 입력값 추가
- application/octet-stream 처리를 위한 Message Converter 추가
    - `HttpMediaTypeNotSupportedException: Content-Type 'application/octet-stream' is not supported` 발생 후, 에러 해결을 위해 application/octet-stream 처리용 Message Converter 추가(상세한 에러 해결 과정은 아래 레퍼런스 참고)

## 📚 Reference
- [[Spring boot] Swagger Spring doc에서 API Request의 Content-Type(multipart/form-data)이 지정되지 않는 문제](https://one-armed-boy.tistory.com/entry/Swagger-RequestPart%EB%A5%BC-%ED%86%B5%ED%95%B4-%ED%8C%8C%EC%9D%BC-Dto-%EB%8F%99%EC%8B%9C-%EC%9A%94%EC%B2%AD-%EC%8B%9C-%EB%B0%9C%EC%83%9D-%EC%97%90%EB%9F%AC)
- [[Spring] Swagger + RequestPart를 통해 파일, Dto 동시 요청 시 발생 에러 핸들링](https://velog.io/@jsb100800/Spring-boot-Swagger-issue1)