### PR TITLE
feat: 식품의약품안전처의 공공데이터 수집 및 가공 후 SQL 파일 추가 (data.sql)

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,1261 +1,2923 @@
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가다랑어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가라지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가래상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가리비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가무락조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가물치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가사리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가숭어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가시망둑', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가시발새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가시베도라치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가시오가피', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가시파래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가오리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가재', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('가지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('각설탕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('각시가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('각시돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('각시서대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('각시수랑', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('각시흰새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('간장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈고리흰오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈래곰보', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈비가공품', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈색 거저리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈색고리돼지고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈색띠매물고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈전갱이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈창갯장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갈파래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감(단감)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감(대봉(갑주백묵))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감(둥시)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감(연시)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감말랭이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감성돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감잎차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('감자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갑오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갓', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('강낭콩', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('강담돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('강도다리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('강준치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('강화우유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개구리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개도박', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개량조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개불', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개서대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개암(헤이즐넛)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('개조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갯가재', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갯강구', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갯기름나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('갯장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('거위 부산물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('거위고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('거위알', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('검복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('검은비늘버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('게걸무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('게르치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('겨자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('견과류', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('결명자차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('경수채', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('계피', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('계피차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고구마', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고들빼기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고등어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고래고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고려엉겅퀴(곤드레)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고로쇠나무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고리매', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고무꺽정이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고사리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고수(향채)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고추냉이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고추씨기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고추장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고춧가루', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고춧잎', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('고형차', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('곤달비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('곤약(구약나물)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('골든세이지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('골뱅이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('곰취', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('곰피', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('곱상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('곳체다슬기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('공심채', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('곶감', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('과·채당절임', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('관절매물고둥(보라골뱅이)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('광동홍어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('괭생이모자반', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('괴도라치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('구갈돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('구기자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('구기자차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('구아바', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('구절초차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('구즈베리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국매리복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국수(소면)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국수(우동)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국수(중국국수)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국수(중면)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국수(쫄면)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국수(칼국수)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국자가리비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국화꽃', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('국화차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('군소', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('군평선이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('굴', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('궁제기서대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귀뚜라미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귀리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귀리밥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤 주스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(궁천조생+노지)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(궁천조생+하우스)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(레드향)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(신예감)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(온주밀감)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(유라조생+하우스)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(일남1호)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(임온주)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(천혜향)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(하례조생+노지)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(하례조생+하우스)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(한라봉)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(황금향)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('귤(흥진조생)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('그라비새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('그물베도라치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('근대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('금강참게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('금귤', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('금눈돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('기러기알', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('기름가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('기름종개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('기장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('긴고둥(긴뿔고둥)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('긴꼬리벵에돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('긴뿔천길새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('김', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('김밥용김', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('김자반', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('김칫속', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('까나리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('까치복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('까치상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('까칠복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('깨다시꽃게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('깨소금', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꺽저기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꼬막', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꼬시래기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꼬치고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꼴뚜기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꼼치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꼽새돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꽁지양태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꽁치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꽁치(과메기)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꽃게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꽃새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꽃송이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꽃양배추(콜리플라워)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꾸지뽕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꿀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꿀(밤)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꿀(아카시아)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꿀(잡화)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꿀(토종)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꿀풀(하고초)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('꿩고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('끈멍게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('나도팽나무버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('나비가오리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('나토', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('나팔고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('낙지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('난', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('날개다랑어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('날개콩', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('날치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('납작파래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('납지리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('냉동과일', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('냉이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('넙치(광어)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('네동가리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('노랑가오리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('노랑벤자리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('노래미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('노루궁뎅이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('녹두', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('녹두 국수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('녹두묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('녹차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('놀래기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('농어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('농후발효유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('누루시볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('누리장나무잎', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('누에', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('누치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('눈가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('눈강달이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('눈볼대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('눈양태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('눈퉁멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('느타리버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('는쟁이냉이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('능성어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('능이버섯(향버섯)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('다금바리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('다래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('다래나무순차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('다슬기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('다시마', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('단무지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('달강어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('달걀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('달고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('달래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('달팽이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭 부산물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭 부산물(간)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭 부산물(모래주머니)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭 부산물(발)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭 부산물(심장(염통))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭 육수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(가슴(껍질 제거))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(가슴)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(껍질)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(날개)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(넓적다리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(다리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(목)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(살코기)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(아랫다리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭고기(전체)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭발 육수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('닭새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('당귀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('당근', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('당면', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('당밀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대구', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대구횟대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대나무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대두어(흑연)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대롱수염새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대문어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대서양연어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대수리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대왕범바리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대왕붉바리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대왕자바리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대추야자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대추차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대하', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대합', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('대황', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('더덕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('덕대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도다리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도도바리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도라지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도라지차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도루묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도박', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도토리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도토리 국수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도토리묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도화돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('도화양태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('독가시치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('독돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돌가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돌김(둥근돌김)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돌나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돌담치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돌돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돔발상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동갈치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동남참게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동동갈치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동부', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동사리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동아', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동자개(빠가사리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동죽', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동충하초', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('동태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돛양태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(간)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(대장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(맹장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(머리고기)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(발)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(비장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(소장(곱창))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(신장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(심장(염통))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(위(오소리감투))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(자궁)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(직장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(췌장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지 부산물(허파)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지감자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(갈비)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(뒷다리(도가니살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(뒷다리(뒷사태살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(뒷다리(보섭살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(뒷다리(볼기살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(뒷다리(설깃살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(뒷다리(홍두깨살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(뒷다리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(등심(등심덧살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(등심(등심살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(등심(알등심살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(등심)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(목심(목심살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(사태)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(살코기)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(삼겹살(갈매기살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(삼겹살(등갈비))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(삼겹살(삼겹살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(삼겹살(오돌삼겹))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(삼겹살(토시살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(삼겹살)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(안심(안심살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리(꾸리살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리(부채살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리(수육용))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리(앞다리살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리(앞사태살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리(주걱살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리(항정살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지고기(앞다리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('돼지기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('된장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('두드럭고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('두릅', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('두리안', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('두부', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('두충차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('두툽상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('둑중개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('둥굴레', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('둥굴레차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('둥근전복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('드렁허리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('드레싱', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('들기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('들깨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('등가시치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('딸기', False, 5);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('땅콩', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('땅콩기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('땅콩버터', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('때죽', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('떡', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('떡붕어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('떡조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('또띠아', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('뜸부기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('띠구슬다슬기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('라벤다', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('라이마빈스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('라임', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('라임 주스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('라즈베리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('레몬', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('레몬그라스(시트로넬라)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('렌즈콩(렌틸콩)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('로열젤리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('로즈마리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('롱안', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('루꼴라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('리치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('리크', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마가린', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마가목 열매', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마늘', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마늘종', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마루자주새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마요네즈', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('마타리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('만가닥버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('만새기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('말고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('말똥성게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('말백합', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('말전복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('말쥐치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('망고', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('망고스틴', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('망상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('망치고등어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('매끈이고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('매리복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('매생이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('매실', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('매실 절임', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('매오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('매퉁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('맵쌀 국수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('머루', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('머루씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('머위', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('먹갈치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('먹장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멍게(우렁쉥이)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메뚜기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메밀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메밀 국수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메밀 냉면', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메밀묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메주', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메추리고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('메추리알', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멜론', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀(배아)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀(백미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀(칠분도미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀(현미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀(흑미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀국수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀밥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀밥(누룽지)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀밥(백미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀밥(칠분도미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멥쌀밥(현미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멧돼지고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('면실유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('멸치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('명주매물고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('명태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모과', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모닝빵', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모래무지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모링가', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모무늬돌김', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모시조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모시풀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모자반', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('모조리상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('목이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('목이버섯(흰백목이)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('목탁가오리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('목해삼', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('목화씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('목화씨기름(면실유)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('몽치다래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무 절임(치킨무)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무말랭이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무순', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무시래기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무지개송어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무청', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무태뱀장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('무화과', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('문어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('문절망둑', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('문치가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물김치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물냉이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물렁가시붉은새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물레고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물메기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물쑥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('물치다래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('미꾸라지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('미꾸리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('미나리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('미더덕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('미역', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민꽃게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민달고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민들레', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민들레차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('민허리돼지고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(강력밀가루)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(금강밀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(박력밀가루)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(신미찰밀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(중력밀가루)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(카무트)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(통밀가루)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀(흑밀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀가루', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밀복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바게트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바나나', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바다방석고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바다빙어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바닷가재', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바셀라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바지락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('바질', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('박', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('박고지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('박대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('박쥐나무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('반딧불게르치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('반석고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('반원니꼴뚜기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('반지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('발효소시지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밤', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밤버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('방가지똥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('방게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('방사무늬김', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('방어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('방울다다기양배추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('방울토마토', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('배', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('배 과즙', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('배암차즈기(곰보배추)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('배초향(방아)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('배추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('배추김치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('백모근', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('백미돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('백설탕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('백연', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('백합', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('백향과(패션프루트)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('백향과(패션프루트) 주스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('밴댕이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('뱀장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('뱅어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('버들송이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('버찌', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('버터', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('번데기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('벌레문치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('범가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('범돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('베도라치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('베로치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('베이글', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('베이컨', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('벤자리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('벵에돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('별상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('별성대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('별쭉지성대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('병아리콩', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('병어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보구치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보라성게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보리멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보리밥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보리밥 열매', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보리새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보리차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보말고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('보이차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('복분자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('복숭아', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('복숭아(백도)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('복숭아(천도)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('복숭아(천중도)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('복숭아(황도)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('복숭아씨기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('볼기우럭', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('봄동', False, 5);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('부세', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('부시리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('부지갱이(섬쑥부쟁이)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('부채새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('부추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('부침가루', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('북방대합', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('북방전복(참전복)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('북어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('북쪽분홍새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('분쇄가공육제품', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('분유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('분홍꼼치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('불등풀가사리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('불똥꼴뚜기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('불볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붉바리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붉은대게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붉은맛(큰죽합)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붉은멍게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붉은메기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붉은해면', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붕어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('붕장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('브라질너트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('브로콜리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('블랙베리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('블랙커런트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('블루길', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('블루베리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비단가리비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비단고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비비추(이밥추)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비콜라장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비타민채(다채)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('비파', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('빙설탕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('빙어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('빨간대구', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('빨간횟대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('빨강부치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('빵가루', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('뽕나무버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('뽕잎', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('뿔돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('사과', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('사과차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('사당놀래기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('사탕무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('사탕수수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('사프란', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산딸기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산마늘(명이나물)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산분해간장', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산수유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산양유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산자나무 열매(씨벅톤)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산천어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산초', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산호', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('산호말', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('살구', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('살살치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('살오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('살조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('삼나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('삼백초', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('삼붕냐와', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('삼세기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('삼씨(대마씨)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('삼채', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('삼치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('상지차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('상추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('상황버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('새꼬막', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('새다래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('새조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('샛돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('샛멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('생강', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('생햄', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('석굴', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('석류', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('석묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('석이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('선인장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('설탕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('섬초롱', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('성게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('성대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('세고리물레고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('세멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('세발나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('세발낙지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('셀러리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(간)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(골)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(꼬리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(선지(피))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(소장(곱창))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(신장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(심장(염통))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(위(양))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(천엽)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(허파)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소 부산물(혀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소귀나무 열매', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소금', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소리쟁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('소시지', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('솔잎', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지 부산물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지 부산물(간)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지 부산물(골)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지 부산물(신장)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지 부산물(심장(염통))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지 부산물(허파)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지 부산물(혀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지고기(갈비)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지고기(등심)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지고기(살코기)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지고기(어깨)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송아지고기(채끝(채끝살))', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('송화', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쇠갑오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쇠귀나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쇠기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쇠미역', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쇼트닝', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('수랑', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('수리취(떡취)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('수박', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('수박씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('수세미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('수수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('숙주나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('순무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('순채', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('숭어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('스콘', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('스테비아', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('스틸레드연어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('시금치', False, 5);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('시리얼', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('식물성유지', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('식물성크림', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('식빵', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('식용돈지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('식육간편조리', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('식초', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('신선초(명일엽)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('실꼬리돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('실붉돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('실줄고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('싸리버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쌀겨기름(미강유)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쌈무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쌈추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쌍동가리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쌍뿔달재', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쏘가리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쏙', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쏨뱅이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쑤기미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쑥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쑥감펭', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쑥갓', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쑥부쟁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쑥차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('씀바귀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아귀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아떼모야', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아로니아', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아마란스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아마씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아마씨유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아몬드', False, 5);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아몬드유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아보카도', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아보카도오일', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아보카도유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아세로라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아스파라거스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아욱', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아위버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아이비카', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아주까리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아티초크', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아피오스감자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('아홉동가리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('악상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('알로에', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('알팔파', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('애기청각', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('애꼬치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('애느타리버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('애플망고', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('애플수박', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('액상차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('액상커피', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('앨퉁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('앵두', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('야자유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('야콘', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('야콘차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양고기(다리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양념육', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양미리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양배추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양송이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양조간장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양지국물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양태', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양파', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('양하', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어름돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어린양 부산물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어린양고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어린양고기(갈비)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어린양고기(다리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어린양고기(살코기)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어린양고기(어깨)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어수리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('어유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('얼갈이배추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('얼룩통구멍', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('엄나무(개두릅)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('엉겅퀴', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('엘더베리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('여덟동가리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('여주(고야)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('연근', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('연씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('연어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('연어기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('열대비름(아마란스)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('열무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('열쌍동가리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('염교(락교)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('염소고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('염주알다슬기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('영아자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('영지버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('예쁜이해면', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오디', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오레가노', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오렌지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오렴자(카람볼라)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오리고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오리알', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오미자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오미자차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오분자기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('오크라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('옥돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('옥수수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('옥수수 샐러드', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('옥수수기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('옥수수묵', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('올리브 피클', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('올리브유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('올스파이스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('완두', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('왕게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('왕연어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('왕우럭조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('왕우렁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('용가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('용과', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('용다시마', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('용치놀래기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우각바리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우럭', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우럭볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우롱차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우뭇가사리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우엉', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우유(멸균)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('우족국물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('울금', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('웅어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('원두', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('원두분말', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('원추리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('월계수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('위고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('유당분해우유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('유령멍게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('유부', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('유자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('유채', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('유채씨기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('육동가리돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('육두구', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('율무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('율무느타리버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('으깬감자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('으름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('은대구', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('은상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('은어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('은연어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('은행', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('인삼', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('인상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('인스턴트커피', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('임연수어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('입뿔고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잇꽃(홍화)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잇꽃씨기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잉어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잎새버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잎파래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자두', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자라고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자리돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자몽(그레이프프루트)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자운영', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자주복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('자포뱀장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('작두(도두)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잔대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잠두', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잡곡', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잡뼈국물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잣', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('장갱이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('장문볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('장수풍뎅이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('장아찌', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('장어베도라치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('재첩', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잭프루트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('잿방어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('적양무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전갱이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전갱이(치어)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전기가오리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분(감자)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분(고구마)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분(밀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분(쌀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분(옥수수)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분(옥수수+밀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전분(칡뿌리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('전호', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('절임식품', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('점감펭', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('점농어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('점줄우럭', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('접시조개(비단조개)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('젓새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('정어리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('정향', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('제비쑥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('조', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('조각매물고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('조뱅이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('조피볼락(우럭)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('졸복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('좀주름다슬기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('종어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('주꾸미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('주름다슬기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('주름미더덕(오만둥이)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('주름송편게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('주먹물수베기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('죽순', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('준치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('줄가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('줄나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('줄노래미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('줄삼치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('줄새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('줄전갱이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('중멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('중하', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쥐노래미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쥐눈이콩(검정소립콩)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쥐치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('지중해담치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('지충이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('진달래꽃', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('진두발', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('진주담치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('진주조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('질경이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('징거미새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('쪽고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참가리비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참갑오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참개도박', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참게', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참굴', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참김', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참깨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참꼬막', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참꼴뚜기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참다랑어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참다슬기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참다시마', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참담치(홍합)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참마자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참문어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참반디', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참붕어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참빗살나무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참서대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참소라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참외', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참조기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참죽나물(가죽나물)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참홍어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('참홑파래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀 국수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀(백미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀(현미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀(흑미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀밥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀밥(백미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('찹쌀밥(현미)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('창꼴뚜기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('창자파래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('천마', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청각', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청경채', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청국장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청둥오리알', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청멸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청새리상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청자갈치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청포도', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청포도(샤인머스켓)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('청해삼', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('체리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('초밥김', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('초석잠', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('초어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('총각무', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('추출들깨유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('춘장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('취나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('치아바타', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('치아씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('치자꽃', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('치즈', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('치커리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('치커리차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('칠리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('칠면조고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('칠면초', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('칠성갈치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('칠성장어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('칡뿌리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('칡즙', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('침출차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('카놀라유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('카레', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('카모마일차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('카스텔라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('커피', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('케일', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('코끼리조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('코리아타임', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('코코넛', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('코코넛유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('콜라비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('콩(대두)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('콩기름', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('콩기름(대두유)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('콩깍지고둥(털골뱅이)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('콩나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('콩잎', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('퀴노아', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('크랜베리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('크릴', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('큰가리비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('큰구슬우렁이(골뱅이)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('큰논우렁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('큰느타리버섯(새송이버섯)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('큰잎모자반', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('클로렐라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('키위', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('키위(골드)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('키위(그린)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('키조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('킹넙치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('타라곤', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('타임', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('탁자볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('탄산수', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('탱자', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('털탑고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('토굴(벗굴)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('토끼고기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('토란', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('토란대', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('토마토', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('토마토케첩', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('토스카노(잎브로콜리)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('톳', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('통치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('투라치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('툼빌매퉁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('퉁퉁마디(함초)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('퉁퉁마디환(함초환)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('튀김가루', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('틸라피아', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파드득나물(삼엽채)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파래', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파스타', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파스타(마카로니)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파스타(스파게티)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파슬리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파인애플', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파파야', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('파프리카', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('팔완향오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('팜유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('팝콘', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('팥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('팽이버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('팽창제', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('펄닭새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('펄조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('페퍼민트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('평삼치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('포도', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('포도당', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('포도씨유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('포도즙', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('포타벨라', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('표고버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('푸렁통구멍', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('풀망둑', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('풀반지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('풀버섯', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('풋마늘', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('풍선군소', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('프레스햄', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('프로폴리스', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('플럼코트', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피라미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피망', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피뿔고둥', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피스타치오넛', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피조개', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피칸', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('피클', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('학공치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('한식간장', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('한치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해만가리비', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해면', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해바라기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해바라기씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해바라기씨유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해바라기유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해삼', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('해파리', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('햄', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('향미유', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('향신료', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('향어(이스라엘잉어)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호두', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호두유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호밀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호밀(통호밀)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박(국수호박)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박(늙은호박)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박(단호박)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박(애호박)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박(쥬키니)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박(차요테)', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박씨', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박씨분말', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박즙', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('호박해면', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('혹돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('혼합간장', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('혼합소시지', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('혼합식물성유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('혼합식용유', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('혼합장', True, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍가자미', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍감펭', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍다리얼룩새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍연어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍차', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍해삼', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍화씨유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홍화유', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('홑잎나물', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('화살오징어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황놀래기', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황다랑어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황매퉁이', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황설탕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황아귀', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황점볼락', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('황줄돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('후추', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('흉상어', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('흑돔', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('흑설탕', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('흑해삼', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('흰다리새우', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('흰점박이 꽃무지', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('흰점복', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('히메치', False, NULL);
-INSERT INTO ingredient (name, is_nova4, challenge_month) VALUES ('히카마(얌빈)', False, NULL);
+-- Ingredient
+
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1, '가다랑어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (2, '가라지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (3, '가래상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (4, '가리비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (5, '가무락조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (6, '가물치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (7, '가사리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (8, '가숭어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (9, '가시망둑', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (10, '가시발새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (11, '가시베도라치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (12, '가시오가피', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (13, '가시파래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (14, '가오리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (15, '가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (16, '가재', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (17, '가지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (18, '각설탕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (19, '각시가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (20, '각시돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (21, '각시서대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (22, '각시수랑', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (23, '각시흰새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (24, '간장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (25, '갈가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (26, '갈고리흰오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (27, '갈래곰보', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (28, '갈비가공품', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (29, '갈색 거저리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (30, '갈색고리돼지고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (31, '갈색띠매물고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (32, '갈전갱이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (33, '갈창갯장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (34, '갈치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (35, '갈파래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (36, '감', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (37, '감(단감)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (38, '감(대봉(갑주백묵))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (39, '감(둥시)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (40, '감(연시)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (41, '감말랭이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (42, '감성돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (43, '감잎차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (44, '감자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (45, '갑오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (46, '갓', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (47, '강낭콩', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (48, '강담돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (49, '강도다리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (50, '강준치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (51, '강화우유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (52, '개구리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (53, '개도박', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (54, '개량조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (55, '개볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (56, '개불', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (57, '개서대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (58, '개암(헤이즐넛)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (59, '개조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (60, '갯가재', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (61, '갯강구', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (62, '갯기름나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (63, '갯장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (64, '거위 부산물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (65, '거위고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (66, '거위알', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (67, '검복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (68, '검은비늘버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (69, '게걸무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (70, '게르치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (71, '겨자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (72, '견과류', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (73, '결명자차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (74, '경수채', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (75, '계피', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (76, '계피차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (77, '고구마', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (78, '고들빼기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (79, '고등어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (80, '고래고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (81, '고려엉겅퀴(곤드레)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (82, '고로쇠나무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (83, '고리매', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (84, '고무꺽정이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (85, '고비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (86, '고사리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (87, '고수(향채)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (88, '고추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (89, '고추냉이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (90, '고추씨기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (91, '고추장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (92, '고춧가루', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (93, '고춧잎', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (94, '고형차', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (95, '곤달비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (96, '곤약(구약나물)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (97, '골든세이지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (98, '골뱅이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (99, '곰취', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (100, '곰피', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (101, '곱상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (102, '곳체다슬기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (103, '공심채', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (104, '곶감', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (105, '과·채당절임', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (106, '관절매물고둥(보라골뱅이)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (107, '광동홍어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (108, '괭생이모자반', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (109, '괴도라치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (110, '구갈돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (111, '구기자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (112, '구기자차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (113, '구아바', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (114, '구절초차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (115, '구즈베리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (116, '국매리복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (117, '국수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (118, '국수(소면)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (119, '국수(우동)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (120, '국수(중국국수)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (121, '국수(중면)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (122, '국수(쫄면)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (123, '국수(칼국수)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (124, '국자가리비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (125, '국화꽃', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (126, '국화차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (127, '군소', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (128, '군평선이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (129, '굴', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (130, '궁제기서대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (131, '귀뚜라미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (132, '귀리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (133, '귀리밥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (134, '귤', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (135, '귤 주스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (136, '귤(궁천조생+노지)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (137, '귤(궁천조생+하우스)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (138, '귤(레드향)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (139, '귤(신예감)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (140, '귤(온주밀감)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (141, '귤(유라조생+하우스)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (142, '귤(일남1호)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (143, '귤(임온주)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (144, '귤(천혜향)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (145, '귤(하례조생+노지)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (146, '귤(하례조생+하우스)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (147, '귤(한라봉)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (148, '귤(황금향)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (149, '귤(흥진조생)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (150, '그라비새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (151, '그물베도라치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (152, '근대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (153, '금강참게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (154, '금귤', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (155, '금눈돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (156, '기러기알', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (157, '기름가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (158, '기름종개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (159, '기장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (160, '긴고둥(긴뿔고둥)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (161, '긴꼬리벵에돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (162, '긴뿔천길새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (163, '김', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (164, '김밥용김', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (165, '김자반', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (166, '김칫속', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (167, '까나리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (168, '까치복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (169, '까치상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (170, '까칠복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (171, '깨다시꽃게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (172, '깨소금', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (173, '꺽저기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (174, '꼬막', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (175, '꼬시래기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (176, '꼬치고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (177, '꼴뚜기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (178, '꼼치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (179, '꼽새돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (180, '꽁지양태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (181, '꽁치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (182, '꽁치(과메기)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (183, '꽃게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (184, '꽃새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (185, '꽃송이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (186, '꽃양배추(콜리플라워)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (187, '꾸지뽕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (188, '꿀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (189, '꿀(밤)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (190, '꿀(아카시아)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (191, '꿀(잡화)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (192, '꿀(토종)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (193, '꿀풀(하고초)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (194, '꿩고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (195, '끈멍게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (196, '나도팽나무버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (197, '나비가오리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (198, '나토', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (199, '나팔고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (200, '낙지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (201, '난', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (202, '날개다랑어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (203, '날개콩', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (204, '날치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (205, '납작파래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (206, '납지리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (207, '냉동과일', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (208, '냉이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (209, '넙치(광어)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (210, '네동가리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (211, '노랑가오리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (212, '노랑벤자리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (213, '노래미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (214, '노루궁뎅이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (215, '녹두', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (216, '녹두 국수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (217, '녹두묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (218, '녹차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (219, '놀래기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (220, '농어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (221, '농후발효유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (222, '누루시볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (223, '누리장나무잎', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (224, '누에', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (225, '누치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (226, '눈가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (227, '눈강달이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (228, '눈볼대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (229, '눈양태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (230, '눈퉁멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (231, '느타리버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (232, '는쟁이냉이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (233, '능성어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (234, '능이버섯(향버섯)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (235, '다금바리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (236, '다래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (237, '다래나무순차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (238, '다슬기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (239, '다시마', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (240, '단무지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (241, '달강어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (242, '달걀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (243, '달고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (244, '달래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (245, '달팽이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (246, '닭 부산물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (247, '닭 부산물(간)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (248, '닭 부산물(모래주머니)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (249, '닭 부산물(발)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (250, '닭 부산물(심장(염통))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (251, '닭 육수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (252, '닭게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (253, '닭고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (254, '닭고기(가슴(껍질 제거))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (255, '닭고기(가슴)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (256, '닭고기(껍질)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (257, '닭고기(날개)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (258, '닭고기(넓적다리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (259, '닭고기(다리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (260, '닭고기(목)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (261, '닭고기(살코기)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (262, '닭고기(아랫다리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (263, '닭고기(전체)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (264, '닭기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (265, '닭발 육수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (266, '닭새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (267, '당귀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (268, '당근', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (269, '당면', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (270, '당밀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (271, '대게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (272, '대구', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (273, '대구횟대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (274, '대나무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (275, '대두어(흑연)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (276, '대롱수염새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (277, '대멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (278, '대문어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (279, '대서양연어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (280, '대수리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (281, '대왕범바리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (282, '대왕붉바리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (283, '대왕자바리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (284, '대추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (285, '대추야자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (286, '대추차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (287, '대하', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (288, '대합', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (289, '대황', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (290, '더덕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (291, '덕대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (292, '도다리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (293, '도도바리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (294, '도라지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (295, '도라지차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (296, '도루묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (297, '도박', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (298, '도치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (299, '도토리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (300, '도토리 국수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (301, '도토리묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (302, '도화돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (303, '도화양태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (304, '독가시치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (305, '독돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (306, '돌가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (307, '돌김(둥근돌김)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (308, '돌나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (309, '돌담치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (310, '돌돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (311, '돔발상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (312, '동갈치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (313, '동남참게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (314, '동동갈치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (315, '동부', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (316, '동사리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (317, '동아', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (318, '동자개(빠가사리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (319, '동죽', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (320, '동충하초', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (321, '동태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (322, '돛양태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (323, '돼지 부산물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (324, '돼지 부산물(간)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (325, '돼지 부산물(대장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (326, '돼지 부산물(맹장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (327, '돼지 부산물(머리고기)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (328, '돼지 부산물(발)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (329, '돼지 부산물(비장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (330, '돼지 부산물(소장(곱창))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (331, '돼지 부산물(신장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (332, '돼지 부산물(심장(염통))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (333, '돼지 부산물(위(오소리감투))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (334, '돼지 부산물(자궁)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (335, '돼지 부산물(직장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (336, '돼지 부산물(췌장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (337, '돼지 부산물(허파)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (338, '돼지감자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (339, '돼지고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (340, '돼지고기(갈비)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (341, '돼지고기(뒷다리(도가니살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (342, '돼지고기(뒷다리(뒷사태살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (343, '돼지고기(뒷다리(보섭살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (344, '돼지고기(뒷다리(볼기살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (345, '돼지고기(뒷다리(설깃살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (346, '돼지고기(뒷다리(홍두깨살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (347, '돼지고기(뒷다리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (348, '돼지고기(등심(등심덧살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (349, '돼지고기(등심(등심살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (350, '돼지고기(등심(알등심살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (351, '돼지고기(등심)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (352, '돼지고기(목심(목심살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (353, '돼지고기(사태)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (354, '돼지고기(살코기)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (355, '돼지고기(삼겹살(갈매기살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (356, '돼지고기(삼겹살(등갈비))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (357, '돼지고기(삼겹살(삼겹살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (358, '돼지고기(삼겹살(오돌삼겹))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (359, '돼지고기(삼겹살(토시살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (360, '돼지고기(삼겹살)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (361, '돼지고기(안심(안심살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (362, '돼지고기(앞다리(꾸리살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (363, '돼지고기(앞다리(부채살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (364, '돼지고기(앞다리(수육용))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (365, '돼지고기(앞다리(앞다리살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (366, '돼지고기(앞다리(앞사태살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (367, '돼지고기(앞다리(주걱살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (368, '돼지고기(앞다리(항정살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (369, '돼지고기(앞다리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (370, '돼지기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (371, '된장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (372, '두드럭고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (373, '두릅', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (374, '두리안', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (375, '두부', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (376, '두충차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (377, '두툽상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (378, '둑중개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (379, '둥굴레', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (380, '둥굴레차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (381, '둥근전복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (382, '드렁허리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (383, '드레싱', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (384, '들기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (385, '들깨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (386, '등가시치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (387, '딸기', False, 2);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (388, '땅콩', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (389, '땅콩기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (390, '땅콩버터', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (391, '때죽', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (392, '떡', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (393, '떡붕어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (394, '떡조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (395, '또띠아', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (396, '뜸부기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (397, '띠구슬다슬기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (398, '라벤다', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (399, '라이마빈스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (400, '라임', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (401, '라임 주스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (402, '라즈베리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (403, '레몬', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (404, '레몬그라스(시트로넬라)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (405, '렌즈콩(렌틸콩)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (406, '로열젤리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (407, '로즈마리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (408, '롱안', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (409, '루꼴라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (410, '리치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (411, '리크', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (412, '마', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (413, '마가린', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (414, '마가목 열매', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (415, '마늘', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (416, '마늘종', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (417, '마루자주새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (418, '마름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (419, '마요네즈', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (420, '마타리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (421, '만가닥버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (422, '만새기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (423, '말고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (424, '말똥성게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (425, '말백합', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (426, '말전복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (427, '말쥐치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (428, '망고', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (429, '망고스틴', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (430, '망상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (431, '망치고등어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (432, '매끈이고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (433, '매리복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (434, '매생이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (435, '매실', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (436, '매실 절임', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (437, '매오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (438, '매퉁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (439, '맵쌀 국수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (440, '머루', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (441, '머루씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (442, '머위', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (443, '먹갈치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (444, '먹장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (445, '멍게(우렁쉥이)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (446, '메기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (447, '메뚜기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (448, '메밀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (449, '메밀 국수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (450, '메밀 냉면', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (451, '메밀묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (452, '메주', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (453, '메추리고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (454, '메추리알', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (455, '멜론', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (456, '멥쌀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (457, '멥쌀(배아)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (458, '멥쌀(백미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (459, '멥쌀(칠분도미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (460, '멥쌀(현미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (461, '멥쌀(흑미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (462, '멥쌀국수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (463, '멥쌀밥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (464, '멥쌀밥(누룽지)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (465, '멥쌀밥(백미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (466, '멥쌀밥(칠분도미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (467, '멥쌀밥(현미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (468, '멧돼지고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (469, '면실유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (470, '멸치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (471, '명주매물고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (472, '명태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (473, '모과', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (474, '모닝빵', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (475, '모래무지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (476, '모링가', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (477, '모무늬돌김', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (478, '모시조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (479, '모시풀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (480, '모유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (481, '모자반', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (482, '모조리상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (483, '목이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (484, '목이버섯(흰백목이)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (485, '목탁가오리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (486, '목해삼', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (487, '목화씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (488, '목화씨기름(면실유)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (489, '몽치다래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (490, '무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (491, '무 절임(치킨무)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (492, '무말랭이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (493, '무순', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (494, '무시래기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (495, '무지개송어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (496, '무청', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (497, '무태뱀장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (498, '무화과', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (499, '묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (500, '문어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (501, '문절망둑', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (502, '문치가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (503, '물가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (504, '물김치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (505, '물냉이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (506, '물렁가시붉은새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (507, '물레고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (508, '물메기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (509, '물쑥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (510, '물치다래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (511, '미꾸라지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (512, '미꾸리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (513, '미나리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (514, '미더덕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (515, '미역', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (516, '민꽃게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (517, '민달고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (518, '민들레', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (519, '민들레차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (520, '민어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (521, '민태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (522, '민트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (523, '민허리돼지고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (524, '밀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (525, '밀(강력밀가루)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (526, '밀(금강밀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (527, '밀(박력밀가루)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (528, '밀(신미찰밀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (529, '밀(중력밀가루)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (530, '밀(카무트)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (531, '밀(통밀가루)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (532, '밀(흑밀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (533, '밀가루', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (534, '밀복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (535, '바게트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (536, '바나나', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (537, '바다방석고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (538, '바다빙어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (539, '바닷가재', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (540, '바셀라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (541, '바지락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (542, '바질', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (543, '박', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (544, '박고지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (545, '박대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (546, '박쥐나무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (547, '반딧불게르치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (548, '반석고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (549, '반원니꼴뚜기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (550, '반지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (551, '발효소시지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (552, '밤', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (553, '밤버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (554, '방가지똥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (555, '방게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (556, '방사무늬김', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (557, '방어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (558, '방울다다기양배추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (559, '방울토마토', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (560, '배', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (561, '배 과즙', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (562, '배암차즈기(곰보배추)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (563, '배초향(방아)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (564, '배추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (565, '배추김치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (566, '백모근', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (567, '백미돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (568, '백설탕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (569, '백연', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (570, '백합', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (571, '백향과(패션프루트)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (572, '백향과(패션프루트) 주스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (573, '밴댕이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (574, '뱀장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (575, '뱅어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (576, '버들송이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (577, '버찌', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (578, '버터', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (579, '번데기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (580, '벌레문치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (581, '범가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (582, '범돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (583, '베도라치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (584, '베로치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (585, '베이글', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (586, '베이컨', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (587, '벤자리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (588, '벵에돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (589, '별상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (590, '별성대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (591, '별쭉지성대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (592, '병아리콩', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (593, '병어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (594, '보구치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (595, '보라성게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (596, '보리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (597, '보리멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (598, '보리밥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (599, '보리밥 열매', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (600, '보리새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (601, '보리차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (602, '보말고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (603, '보이차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (604, '복분자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (605, '복숭아', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (606, '복숭아(백도)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (607, '복숭아(천도)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (608, '복숭아(천중도)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (609, '복숭아(황도)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (610, '복숭아씨기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (611, '볼기우럭', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (612, '볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (613, '봄동', False, 2);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (614, '부세', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (615, '부시리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (616, '부지갱이(섬쑥부쟁이)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (617, '부채새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (618, '부추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (619, '부침가루', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (620, '북방대합', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (621, '북방전복(참전복)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (622, '북어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (623, '북쪽분홍새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (624, '분쇄가공육제품', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (625, '분유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (626, '분홍꼼치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (627, '불등풀가사리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (628, '불똥꼴뚜기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (629, '불볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (630, '붉바리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (631, '붉은대게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (632, '붉은맛(큰죽합)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (633, '붉은멍게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (634, '붉은메기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (635, '붉은해면', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (636, '붕어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (637, '붕장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (638, '브라질너트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (639, '브로콜리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (640, '블랙베리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (641, '블랙커런트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (642, '블루길', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (643, '블루베리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (644, '비단가리비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (645, '비단고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (646, '비름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (647, '비비추(이밥추)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (648, '비콜라장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (649, '비타민채(다채)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (650, '비트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (651, '비파', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (652, '빙설탕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (653, '빙어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (654, '빨간대구', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (655, '빨간횟대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (656, '빨강부치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (657, '빵가루', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (658, '뽕나무버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (659, '뽕잎', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (660, '뿔돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (661, '사과', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (662, '사과차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (663, '사당놀래기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (664, '사탕무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (665, '사탕수수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (666, '사프란', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (667, '산딸기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (668, '산마늘(명이나물)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (669, '산분해간장', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (670, '산수유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (671, '산양유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (672, '산자나무 열매(씨벅톤)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (673, '산천어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (674, '산초', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (675, '산호', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (676, '산호말', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (677, '살구', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (678, '살살치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (679, '살오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (680, '살조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (681, '삼나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (682, '삼백초', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (683, '삼붕냐와', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (684, '삼세기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (685, '삼씨(대마씨)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (686, '삼채', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (687, '삼치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (688, '상지차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (689, '상추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (690, '상황버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (691, '새꼬막', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (692, '새다래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (693, '새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (694, '새조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (695, '샛돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (696, '샛멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (697, '생강', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (698, '생햄', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (699, '석굴', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (700, '석류', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (701, '석묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (702, '석이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (703, '선인장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (704, '설탕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (705, '섬초롱', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (706, '성게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (707, '성대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (708, '세고리물레고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (709, '세멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (710, '세발나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (711, '세발낙지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (712, '셀러리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (713, '소 부산물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (714, '소 부산물(간)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (715, '소 부산물(골)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (716, '소 부산물(꼬리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (717, '소 부산물(선지(피))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (718, '소 부산물(소장(곱창))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (719, '소 부산물(신장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (720, '소 부산물(심장(염통))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (721, '소 부산물(위(양))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (722, '소 부산물(천엽)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (723, '소 부산물(허파)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (724, '소 부산물(혀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (725, '소고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (726, '소귀나무 열매', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (727, '소금', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (728, '소라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (729, '소리쟁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (730, '소멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (731, '소시지', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (732, '솔잎', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (733, '송아지 부산물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (734, '송아지 부산물(간)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (735, '송아지 부산물(골)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (736, '송아지 부산물(신장)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (737, '송아지 부산물(심장(염통))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (738, '송아지 부산물(허파)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (739, '송아지 부산물(혀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (740, '송아지고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (741, '송아지고기(갈비)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (742, '송아지고기(등심)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (743, '송아지고기(살코기)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (744, '송아지고기(어깨)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (745, '송아지고기(채끝(채끝살))', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (746, '송어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (747, '송이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (748, '송화', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (749, '쇠갑오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (750, '쇠귀나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (751, '쇠기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (752, '쇠미역', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (753, '쇼트닝', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (754, '수랑', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (755, '수리취(떡취)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (756, '수박', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (757, '수박씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (758, '수세미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (759, '수수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (760, '숙주나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (761, '순무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (762, '순채', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (763, '숭어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (764, '스콘', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (765, '스테비아', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (766, '스틸레드연어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (767, '시금치', False, 2);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (768, '시리얼', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (769, '식물성유지', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (770, '식물성크림', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (771, '식빵', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (772, '식용돈지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (773, '식육간편조리', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (774, '식초', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (775, '신선초(명일엽)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (776, '실꼬리돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (777, '실붉돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (778, '실줄고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (779, '싸리버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (780, '쌀겨기름(미강유)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (781, '쌈무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (782, '쌈추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (783, '쌍동가리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (784, '쌍뿔달재', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (785, '쏘가리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (786, '쏙', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (787, '쏨뱅이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (788, '쑤기미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (789, '쑥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (790, '쑥감펭', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (791, '쑥갓', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (792, '쑥부쟁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (793, '쑥차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (794, '씀바귀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (795, '아귀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (796, '아떼모야', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (797, '아로니아', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (798, '아마란스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (799, '아마씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (800, '아마씨유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (801, '아몬드', False, 2);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (802, '아몬드유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (803, '아보카도', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (804, '아보카도오일', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (805, '아보카도유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (806, '아세로라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (807, '아스파라거스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (808, '아욱', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (809, '아위버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (810, '아이비카', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (811, '아주까리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (812, '아티초크', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (813, '아피오스감자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (814, '아홉동가리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (815, '악상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (816, '알로에', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (817, '알팔파', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (818, '애기청각', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (819, '애꼬치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (820, '애느타리버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (821, '애플망고', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (822, '애플수박', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (823, '액상차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (824, '액상커피', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (825, '앨퉁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (826, '앵두', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (827, '야자유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (828, '야콘', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (829, '야콘차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (830, '양고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (831, '양고기(다리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (832, '양념육', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (833, '양미리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (834, '양배추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (835, '양송이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (836, '양조간장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (837, '양지국물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (838, '양태', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (839, '양파', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (840, '양하', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (841, '어름돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (842, '어린양 부산물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (843, '어린양고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (844, '어린양고기(갈비)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (845, '어린양고기(다리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (846, '어린양고기(살코기)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (847, '어린양고기(어깨)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (848, '어묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (849, '어수리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (850, '어유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (851, '얼갈이배추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (852, '얼룩통구멍', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (853, '엄나무(개두릅)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (854, '엉겅퀴', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (855, '엘더베리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (856, '여덟동가리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (857, '여주(고야)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (858, '연근', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (859, '연씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (860, '연어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (861, '연어기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (862, '열대비름(아마란스)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (863, '열무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (864, '열쌍동가리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (865, '염교(락교)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (866, '염소고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (867, '염주알다슬기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (868, '영아자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (869, '영지버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (870, '예쁜이해면', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (871, '오디', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (872, '오레가노', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (873, '오렌지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (874, '오렴자(카람볼라)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (875, '오리고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (876, '오리알', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (877, '오미자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (878, '오미자차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (879, '오분자기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (880, '오이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (881, '오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (882, '오크라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (883, '옥돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (884, '옥수수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (885, '옥수수 샐러드', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (886, '옥수수기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (887, '옥수수묵', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (888, '올리브 피클', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (889, '올리브유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (890, '올스파이스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (891, '완두', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (892, '왕게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (893, '왕연어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (894, '왕우럭조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (895, '왕우렁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (896, '용가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (897, '용과', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (898, '용다시마', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (899, '용치놀래기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (900, '우각바리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (901, '우럭', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (902, '우럭볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (903, '우롱차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (904, '우뭇가사리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (905, '우엉', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (906, '우유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (907, '우유(멸균)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (908, '우족국물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (909, '울금', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (910, '웅어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (911, '원두', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (912, '원두분말', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (913, '원추리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (914, '월계수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (915, '위고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (916, '유당분해우유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (917, '유령멍게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (918, '유부', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (919, '유자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (920, '유채', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (921, '유채씨기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (922, '육동가리돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (923, '육두구', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (924, '율무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (925, '율무느타리버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (926, '으깬감자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (927, '으름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (928, '은대구', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (929, '은상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (930, '은어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (931, '은연어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (932, '은행', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (933, '인삼', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (934, '인상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (935, '인스턴트커피', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (936, '임연수어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (937, '입뿔고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (938, '잇꽃(홍화)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (939, '잇꽃씨기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (940, '잉어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (941, '잎새버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (942, '잎파래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (943, '자두', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (944, '자라고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (945, '자리돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (946, '자멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (947, '자몽(그레이프프루트)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (948, '자운영', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (949, '자주복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (950, '자포뱀장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (951, '작두(도두)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (952, '잔대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (953, '잠두', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (954, '잡곡', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (955, '잡뼈국물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (956, '잣', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (957, '장갱이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (958, '장문볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (959, '장수풍뎅이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (960, '장아찌', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (961, '장어베도라치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (962, '재첩', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (963, '잭프루트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (964, '잿방어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (965, '적양무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (966, '전갱이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (967, '전갱이(치어)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (968, '전기가오리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (969, '전복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (970, '전분', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (971, '전분(감자)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (972, '전분(고구마)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (973, '전분(밀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (974, '전분(쌀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (975, '전분(옥수수)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (976, '전분(옥수수+밀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (977, '전분(칡뿌리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (978, '전어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (979, '전호', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (980, '절임식품', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (981, '점감펭', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (982, '점농어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (983, '점줄우럭', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (984, '접시조개(비단조개)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (985, '젓새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (986, '정어리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (987, '정향', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (988, '제비쑥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (989, '조', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (990, '조각매물고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (991, '조뱅이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (992, '조피볼락(우럭)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (993, '졸복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (994, '좀주름다슬기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (995, '종어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (996, '주꾸미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (997, '주름다슬기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (998, '주름미더덕(오만둥이)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (999, '주름송편게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1000, '주먹물수베기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1001, '죽순', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1002, '준치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1003, '줄가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1004, '줄나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1005, '줄노래미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1006, '줄삼치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1007, '줄새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1008, '줄전갱이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1009, '중멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1010, '중하', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1011, '쥐노래미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1012, '쥐눈이콩(검정소립콩)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1013, '쥐치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1014, '지중해담치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1015, '지충이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1016, '진달래꽃', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1017, '진두발', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1018, '진주담치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1019, '진주조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1020, '질경이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1021, '징거미새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1022, '쪽고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1023, '참가리비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1024, '참가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1025, '참갑오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1026, '참개도박', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1027, '참게', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1028, '참고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1029, '참굴', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1030, '참기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1031, '참김', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1032, '참깨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1033, '참꼬막', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1034, '참꼴뚜기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1035, '참나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1036, '참다랑어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1037, '참다슬기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1038, '참다시마', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1039, '참담치(홍합)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1040, '참돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1041, '참마자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1042, '참문어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1043, '참반디', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1044, '참붕어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1045, '참빗살나무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1046, '참서대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1047, '참소라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1048, '참외', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1049, '참조기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1050, '참죽나물(가죽나물)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1051, '참치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1052, '참홍어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1053, '참홑파래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1054, '찹쌀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1055, '찹쌀 국수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1056, '찹쌀(백미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1057, '찹쌀(현미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1058, '찹쌀(흑미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1059, '찹쌀밥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1060, '찹쌀밥(백미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1061, '찹쌀밥(현미)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1062, '창꼴뚜기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1063, '창자파래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1064, '천마', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1065, '청각', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1066, '청경채', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1067, '청국장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1068, '청둥오리알', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1069, '청멸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1070, '청새리상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1071, '청어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1072, '청자갈치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1073, '청포도', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1074, '청포도(샤인머스켓)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1075, '청해삼', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1076, '체리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1077, '초밥김', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1078, '초석잠', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1079, '초어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1080, '총각무', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1081, '추출들깨유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1082, '춘장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1083, '취나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1084, '치아바타', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1085, '치아씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1086, '치자꽃', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1087, '치즈', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1088, '치커리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1089, '치커리차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1090, '칠리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1091, '칠면조고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1092, '칠면초', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1093, '칠성갈치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1094, '칠성장어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1095, '칡뿌리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1096, '칡즙', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1097, '침출차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1098, '카놀라유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1099, '카레', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1100, '카모마일차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1101, '카스텔라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1102, '커피', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1103, '케일', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1104, '코끼리조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1105, '코리아타임', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1106, '코코넛', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1107, '코코넛유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1108, '콜라비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1109, '콩(대두)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1110, '콩기름', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1111, '콩기름(대두유)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1112, '콩깍지고둥(털골뱅이)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1113, '콩나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1114, '콩잎', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1115, '퀴노아', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1116, '크랜베리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1117, '크릴', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1118, '큰가리비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1119, '큰구슬우렁이(골뱅이)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1120, '큰논우렁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1121, '큰느타리버섯(새송이버섯)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1122, '큰잎모자반', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1123, '클로렐라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1124, '키위', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1125, '키위(골드)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1126, '키위(그린)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1127, '키조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1128, '킹넙치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1129, '타라곤', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1130, '타임', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1131, '탁자볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1132, '탄산수', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1133, '탱자', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1134, '털탑고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1135, '토굴(벗굴)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1136, '토끼고기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1137, '토란', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1138, '토란대', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1139, '토마토', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1140, '토마토케첩', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1141, '토스카노(잎브로콜리)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1142, '톳', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1143, '통치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1144, '투라치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1145, '툼빌매퉁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1146, '퉁퉁마디(함초)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1147, '퉁퉁마디환(함초환)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1148, '튀김가루', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1149, '틸라피아', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1150, '파', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1151, '파드득나물(삼엽채)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1152, '파래', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1153, '파스타', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1154, '파스타(마카로니)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1155, '파스타(스파게티)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1156, '파슬리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1157, '파인애플', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1158, '파파야', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1159, '파프리카', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1160, '팔완향오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1161, '팜유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1162, '팝콘', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1163, '팥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1164, '팽이버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1165, '팽창제', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1166, '펄닭새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1167, '펄조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1168, '페퍼민트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1169, '평삼치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1170, '포도', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1171, '포도당', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1172, '포도씨유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1173, '포도즙', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1174, '포타벨라', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1175, '표고버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1176, '푸렁통구멍', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1177, '풀망둑', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1178, '풀반지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1179, '풀버섯', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1180, '풋마늘', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1181, '풍선군소', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1182, '프레스햄', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1183, '프로폴리스', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1184, '플럼코트', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1185, '피', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1186, '피라미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1187, '피망', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1188, '피뿔고둥', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1189, '피스타치오넛', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1190, '피조개', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1191, '피칸', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1192, '피클', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1193, '학공치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1194, '한식간장', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1195, '한치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1196, '해만가리비', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1197, '해면', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1198, '해바라기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1199, '해바라기씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1200, '해바라기씨유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1201, '해바라기유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1202, '해삼', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1203, '해파리', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1204, '햄', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1205, '향미유', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1206, '향신료', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1207, '향어(이스라엘잉어)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1208, '호두', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1209, '호두유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1210, '호밀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1211, '호밀(통호밀)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1212, '호박', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1213, '호박(국수호박)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1214, '호박(늙은호박)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1215, '호박(단호박)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1216, '호박(애호박)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1217, '호박(쥬키니)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1218, '호박(차요테)', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1219, '호박돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1220, '호박씨', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1221, '호박씨분말', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1222, '호박즙', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1223, '호박해면', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1224, '혹돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1225, '혼합간장', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1226, '혼합소시지', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1227, '혼합식물성유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1228, '혼합식용유', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1229, '혼합장', True, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1230, '홍가자미', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1231, '홍감펭', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1232, '홍다리얼룩새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1233, '홍어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1234, '홍연어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1235, '홍차', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1236, '홍치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1237, '홍해삼', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1238, '홍화씨유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1239, '홍화유', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1240, '홑잎나물', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1241, '화살오징어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1242, '황놀래기', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1243, '황다랑어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1244, '황돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1245, '황매퉁이', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1246, '황볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1247, '황설탕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1248, '황아귀', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1249, '황어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1250, '황점볼락', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1251, '황줄돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1252, '후추', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1253, '흉상어', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1254, '흑돔', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1255, '흑설탕', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1256, '흑해삼', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1257, '흰다리새우', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1258, '흰점박이 꽃무지', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1259, '흰점복', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1260, '히메치', False, NULL);
+INSERT INTO ingredient (id, name, is_nova4, challenge_month) VALUES (1261, '히카마(얌빈)', False, NULL);
+
+-- member --
+INSERT INTO member (
+    allergy_abalone,
+    allergy_beef,
+    allergy_buckwheat,
+    allergy_chicken,
+    allergy_dairy,
+    allergy_egg,
+    allergy_grain,
+    allergy_mackerel,
+    allergy_milk,
+    allergy_mussel,
+    allergy_oyster,
+    allergy_peach,
+    allergy_peanut,
+    allergy_pine_nut,
+    allergy_pork,
+    allergy_shellfish,
+    allergy_soybean,
+    allergy_squid,
+    allergy_sulfite,
+    allergy_tomato,
+    allergy_walnut,
+    allergy_wheat,
+    allergy_wheat_product,
+    birth_year,
+    meal_style_meat_based,
+    meal_style_mixed,
+    meal_style_vegetable_based,
+    reason_antioxidant_boost,
+    reason_blood_sugar_control,
+    reason_inflammation_reduction,
+    recipe_style_beverage_tea,
+    recipe_style_chinese,
+    recipe_style_dessert,
+    recipe_style_japanese,
+    recipe_style_korean,
+    recipe_style_sauce_jam,
+    recipe_style_western,
+    email,
+    gender,
+    nickname,
+    password,
+    profile_url
+) VALUES (
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    2002,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    'mj@example.com', -- email
+    NULL, -- gender
+    'mj', -- nickname
+    '1234', -- password
+    NULL -- profile_url
+);
+
+-- 레시피 DB --
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (1, 1, '새우 두부 계란찜', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png', '찌기', '염증감소', '한식', '보통', 0, 0, '나트륨의 배출을 도와주는 것으로 알려진 칼륨이 풍부한 시금치와 소금, 간장 등의 양념 대신 새우에 들어있는 간으로 맛을 내요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (1, 375, 1);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (2, 693, 1);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (1, '새우두부계란찜', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (1, '연두부', '75g(3/4모)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (1, '칵테일새우', '20g(5마리)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (1, '달걀', '30g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (1, '생크림', '13g(1큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (1, '무염버터', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (1, '시금치', '10g(3줄기)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (1, '설탕', '5g(1작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (1, '손질된 새우를 끓는 물에 데쳐 건진다.a');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (1, '연두부, 달걀, 생크림, 설탕에 녹인 무염버터를 믹서에 넣고 간 뒤 새우(1)를 함께 섞어 그릇에 담는다.b');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (1, '시금치를 잘게 다져 혼합물 그릇(2)에 뿌리고 찜기에 넣고 중간 불에서 10분 정도 찐다.c');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (1, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00028_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (1, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00028_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (1, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00028_3.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (2, 1, '부추 콩가루 찜', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png', '찌기', '염증감소', '한식', '보통', 0, 0, '콩가루로 버무려 감칠맛과 고소한 맛으로 나트륨 사용량을 줄여보세요. 부추는 피를 맑게 하고 허약 체질을 개선하여 성인병을 예방하는데 효과가 있지만, 알레르기 체질이나 위장이 약한 사람은 부작용이 생길 수 있으니 주의하세요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (3, 618, 2);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (2, '[1인분]조선부추', '50g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (2, '날콩가루', '7g(1⅓작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (2, '·양념장 : 저염간장', '3g(2/3작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (2, '다진 대파', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (2, '요리당', '2g(1/3작은술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (2, '다진 마늘', '2g(1/2쪽)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (2, '고춧가루', '2g(1/3작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (2, '참기름', '2g(1/3작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (2, '참깨', '약간');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (2, '부추는 깨끗이 씻어 물기를 제거하고, 5cm 길이로 썰고 부추에 날콩가루를 넣고 고루 섞이도록 버무린다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (2, '찜기에 면보를 깔고 부추를 넣은 후 김이 오르게 쪄서 파랗게 익힌다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (2, '저염간장에 다진 대파, 다진 마늘, 고춧가루, 요리당 , 참기름, 참깨를 섞어 양념장을 만들고 찐 부추는 그릇에 담아낸다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (2, 'http://www.foodsafetykorea.go.kr/uploadimg/20230206/20230206054820_1675673300714.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (2, 'http://www.foodsafetykorea.go.kr/uploadimg/20230206/20230206054834_1675673314720.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (2, 'http://www.foodsafetykorea.go.kr/uploadimg/20230206/20230206054908_1675673348152.jpg');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (3, 1, '방울토마토 소박이', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00031_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '소금에 절이는 오이 대신 방울토마토를 사용하여 나트륨 섭취를 줄였어요. 토마토에는 과일에 대체로 없는 글루탐산이 풍부하여 감칠맛을 내주며, 겉절이 양념과 잘 어우러져 상큼함과 감칠맛을 내주어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (4, 559, 3);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (5, 1139, 3);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (6, 412, 3);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (7, 543, 3);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (3, '방울토마토 소박이', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (3, '방울토마토', '150g(5개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (3, '부추', '10g(5줄기)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (3, '물', '2ml(1/3작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (3, '통깨', '약간');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (3, '양파', '10g(3×1cm)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (3, '양념장', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (3, '고춧가루', '4g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (3, '멸치액젓', '3g(2/3작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (3, '다진 마늘', '2.5g(1/2쪽)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (3, '매실액', '2g(1/3작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (3, '설탕', '2g(1/3작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (3, '물기를 빼고 2cm 정도의 크기로 썰은 부추와 양파를 양념장에 섞어 양념속을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (3, '깨끗이 씻은 방울토마토는 꼭지를 떼고 윗부분에 칼로 십자모양으로 칼집을 낸다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (3, '칼집을 낸 방울토마토에 양념속을 사이사이에 넣어 버무린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (3, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (3, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (3, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (4, 1, '순두부 사과 소스 오이무침', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00032_2.png', '기타', '염증감소', '한식', '보통', 0, 0, '사과에는 팩틴이 풍부하여 체내 나쁜 콜레스테롤을 감소시키고 나트륨 배출을 촉진시켜줘요. 순두부와 사과를 갈아 만든 소스는 맵고 짠 자극적인 간이 아닌 재료 그대로의 새콤달콤한 맛과 깔끔한 맛을 내요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (8, 375, 4);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (9, 661, 4);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (10, 880, 4);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (11, 490, 4);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (4, '오이무침', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (4, '오이', '70g(1/3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (4, '다진 땅콩', '10g(1큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (4, '순두부', '40g(1/8봉지)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (4, '사과', '50g(1/3개)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (4, '순두부사과 소스', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (4, '사과, 순두부를 믹서에 넣고 곱게 갈아 소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (4, '오이는 소금으로 문질러 씻어 반을 갈라 씨를 제거하고 어슷썰기를 한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (4, '썰어 놓은 오이에 순두부사과 소스를 넣고 버무린 후 다진 땅콩을 뿌려 마무리 한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (4, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00032_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (4, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00032_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (4, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00032_3.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (5, 1, '된장국', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00037_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '된장국의 된장 사용량을 줄이기 위해 두부와 감자 등의 재료를 갈아 넣으면 담백한 된장국을 맛볼 수 있어요.
+된장의 양을 적게 사용함으로 나트륨 섭취를 줄일 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (12, 371, 5);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (5, '된장국', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (5, '두부', '20g(2×2×2cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (5, '애느타리버섯', '20g(4가닥)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (5, '감자', '10g(4×3×1cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (5, '물', '300ml(1½컵)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (5, '양파', '10g(2×1cm)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (5, '대파', '10g(5cm)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (5, '된장', '5g(1작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (5, '감자, 양파는 얇게 썰고 애느타리 버섯은 썰어 달궈진 팬에 굽는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (5, '냄비에 물을 붓고 된장을 푼 뒤 감자, 양파, 두부를 넣어 재료가 투명해지게 끓인 후 된장국의 재료를 건져서 믹서에 넣어 갈고 된장국에 넣어 한번 더 끓인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (5, '구운 애느타리버섯과 대파를 국에 넣어 끓인 후 그릇에 담는다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (5, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00037_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (5, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00037_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (5, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00037_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (6, 1, '표고버섯 청경채국', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00038_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '표고버섯 밑둥을 육수에 넣어 감칠맛을 더하고, 멸치와 다시마는 다량의 소금 없이도 국물 맛을 깊게 만들어 주는 역할을 해요. 건표고버섯은 햇볕에 말리는 과정에서 만들어진 비타민 D가 풍부해 칼슘 흡수를 도와 골다공증 예방에 좋은 식품이예요. 생표고버섯에는 비타민 D가 거의 들어있지 않아요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (13, 1175, 6);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (14, 1066, 6);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (6, '멸치육수 : 국물용 멸치', '5g(3마리)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (6, '다시마', '1장(5×1cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (6, '표고버섯 기둥', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (6, '물', '300ml(1½컵)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (6, '채소준비 : 청경채', '20g(1개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (6, '표고버섯', '20g(2장)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (6, '양파', '10g(2×1cm)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (6, '국간장', '5g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (6, '다진 마늘', '2g(1/3작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (6, '찬물에 표고버섯,머리와 내장을 제거한 멸치,
+다시마, 양파를 넣어 중간 불에서 10분 정도
+끓여 멸치육수를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (6, '육수의 표고버섯 기둥, 멸치, 다시마, 양파를 건진 후 표고버섯은 편으로 썰고 청경채는 4cm 크기로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (6, '끓는 육수에 준비한 표고버섯과 청경채를 넣고 국간장으로 간을 한 후 마늘을 넣어 한소끔 끓인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (6, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00038_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (6, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00038_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (6, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00038_4.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (7, 1, '치커리샐러드와 올리브 마늘 소스', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00095_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '치커리를 육류와 함께 섭취하면 치커리의 산뜻한 맛으로 입맛을 돋우고 섬유소의 섭취를 늘릴 수 있으며 동맥경화를 예방하는데 도움이 된답니다. 치커리에는 칼륨이 많아 육류나 고나트륨 식사시 함께 섭취하면 체내나트륨 배출에 효과적이에요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (15, 1088, 7);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (16, 415, 7);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (17, 412, 7);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (7, '치커리 샐러드 : 치커리', '30g(10줄기)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (7, '적양배추', '15g(5×3cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (7, '당근', '5g(3×1×1cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (7, '올리브마늘 드레싱 : 올리브유', '10g(2작은술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (7, '양파', '10g(2×1cm)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (7, '식초', '5g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (7, '설탕', '5g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (7, '마늘', '5g(1쪽)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (7, '올리브유, 식초, 설탕, 다진 마늘을 섞어 거품기로 충분히 저어주어 올리브마늘 드레싱을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (7, '치커리는 싱싱하게 찬물에 담갔다가 물기를 뺀 후 한입 크기로 자르고, 적양배추, 양파, 당근은 곱게채를 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (7, '접시에 준비한 치커리, 적양배추, 양파, 당근을 담고 올리브마늘 드레싱을 뿌린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (7, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00095_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (7, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00095_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (7, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00095_4.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (8, 1, '스트로베리 샐러드', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00087_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '딸기는 칼륨이 풍부하여 나트륨 배출에 뛰어나지만 칼슘이 부족한 과일이예요. 그렇기 때문에 칼슘이 풍부한 요거트나 기타 유제품과 함께 섭취하면 좋아요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (8, '스트로베리 샐러드', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (8, '딸기', '70g(7개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (8, '플레인요거트', '85g(1개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (8, '양상추', '70g(2장)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (8, '메추리알', '30g(3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (8, '블루베리', '15g(1큰술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (8, '식초', '약간');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (8, '소금', '약간');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (8, '찬물이 담긴 냄비에 식초, 소금을 넣고 메추리알을 삶는다. 물이 끓어오르면 5분 정도 더 삶아 찬물에 헹군 후 껍질을 벗기고 반으로 자른다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (8, '딸기를 흐르는 물에 가볍게 씻어 꼭지를 제거한 후 물기를 빼고 반으로 자른다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (8, '양상추는 찬물에 담갔다가 물기를 빼고 한입 크기로 찢은 후 접시에 양상추, 딸기, 블루베리, 메추리알을 담고 플레인요거트를 끼얹는다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (8, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00087_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (8, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00087_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (8, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00087_4.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (9, 1, '시금치 우유 소스와 그린매쉬드포테이토', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00089_1.png', '찌기', '염증감소', '한식', '보통', 0, 0, '시금치에 풍부한 칼륨과 우유의 칼슘은 나트륨 배출을 도와줘요. 감자도 칼륨이 풍부한 채소이지만 감자에 부족한 칼슘을 유제품과 함께 섭취하면 칼슘을 보충 받을 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (18, 767, 9);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (19, 906, 9);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (9, '그린매쉬드포테이토 : 감자', '80g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (9, '시금치우유 소스', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (9, '아몬드', '2g(1알)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (9, '크랜베리', '3g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (9, '치커리', '약간');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (9, '시금치우유 소스 : 시금치', '10g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (9, '우유', '10g(2작은술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (9, '설탕', '2g(1/3작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (9, '시금치는 끓는 소금물에 데쳐 찬물에 헹구어 물기를 짜고 우유를 넣고 블렌더에 곱게 갈아 체에 거른다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (9, '껍질 벗긴 감자는 찜기에 넣어 20분 정도 삶고 꺼내서 으깨고, 아몬드는 잘게 다지며, 치커리는 곱게 다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (9, '으깬 감자, 다진 치커리, 시금치 우유소스, 설탕을 넣고 섞어 접시에 담고 아몬드, 크랜베리를 올리고 시금치우유 소스를 곁들인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (9, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00089_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (9, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00089_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (9, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00089_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (10, 1, '버섯구이와 두부타르타르 소스', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00091_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '새송이 버섯은 칼륨 함량이 높아 육류와 함께 섭취하면 혈중 콜레스테롤 수치를 낮추는데 효과가 있어요.
+나트륨이 많은 간장이나 소금 대신 겨자, 레몬 등을 이용한 소스로 나트륨 함량을 줄여보세요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (20, 375, 10);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (10, '버섯구이 : 새송이버섯', '70g(7개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (10, '곁들임 : 치커리', '10g(3줄기)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (10, '두부타르타르 소스 : 연두부', '30g(1/4모)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (10, '다진 양파', '10g(2작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (10, '다진 오이피클', '10g(2작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (10, '흰 후추', '약간');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (10, '올리브유', '10g(2작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (10, '식초', '5g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (10, '레몬즙', '3g(2/3작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (10, '머스터드', '3g(2/3작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (10, '꿀', '2g(1/3작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (10, '곱게 다진 양파와 오이피클은 물기를 짠다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (10, '연두부에 다진 양파, 다진 오이피클, 올리브유, 머스터드, 후추, 꿀, 식초, 레몬즙을 넣어 두부타르타르 소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (10, '새송이버섯은 0.5cm 두께로 썰고 프라이팬에 노릇하게 구워준 후 접시에 새송이버섯과 치커리를 담고 소스를 곁들인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (10, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00091_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (10, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00091_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (10, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00091_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (11, 1, '구운채소와 간장레몬 소스', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00093_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '채소와 버섯류에는 대부분 나트륨 배출에 효과적인 칼륨이 함유되어 있어 채소를 많이 섭취하는 것이 저나트륨 식단의 기본이에요. 레몬즙은 음식의 짠맛을 감추고 간장과 함께 사용하면 간장의 감칠맛을 상승시키는 효
+과도 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (21, 24, 11);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (22, 403, 11);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '구운채소 : 가지', '20g(3cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '호박', '50g(1/3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '새송이버섯', '15g(3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '발사믹크레마', '15g(1큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '빨강 파프리카', '3g(3×1cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '노랑 파프리카', '3g(3×1cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '청피망', '3g(3×1cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (11, '간장 레몬 소스 : 저염간장', '5g(1작은술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (11, '양파', '15g(1/8개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (11, '올리브유', '약간');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (11, '식초', '15g(1큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (11, '설탕', '10g(1큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (11, '레몬즙', '5g(1작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (11, '저염간장, 식초, 레몬즙, 설탕을 혼합하여 간장레몬 소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (11, '호박, 가지, 새송이버섯은 3cm 길이로 자른 후 얇은 편으로 채 썰고, 양파, 파프리카, 피망은 호박 길이로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (11, '가지, 호박, 새송이버섯, 양파, 파프리카, 피망에 올리브유를 바르고 달궈진 그릴 팬에 구운 후 접시에 담고 발사믹 크레타를 뿌리고 간장레몬 소스를 곁들인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (11, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00093_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (11, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00093_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (11, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00093_3.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (12, 1, '브로콜리 컬리플라워 샐러드와 두유 요거트 소스', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00094_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '브로콜리와 컬리플라워를 데치는 과정에서만 소금을 넣어 맛과 색은 살려주고 소금 사용은 줄였어요, 또한 마요네즈 대신 두유를 사용하면 맛은 고소해지고 나트륨 배설은 증가 시킬 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (23, 639, 12);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '브로콜리컬리플라워 샐러드 : 브로콜리', '40g(1/5송이)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '컬리플라워', '40g(1/3송이)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '적양파', '10g(2×1cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '강낭콩', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '건포도', '5알');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '호두', '1/2알');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '두유요거트 소스 : 두유', '50g(3⅓큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (12, '플레인요거트', '20g(1⅓큰술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (12, '소금', '약간');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (12, '레몬즙', '5g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (12, '설탕', '약간');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (12, '두유에 플레인요거트와 레몬즙, 설탕을 넣고 잘 섞어 두유요거트 소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (12, '강낭콩은 물에 불린 후 콩과 물을 1:2.5로 넣고 20~25분 삶아 건지고 브로콜리와 컬리플라워는 한입 크기로 썰어 끓는 소금물에 살짝 데쳐 찬물에 헹궈 물기를 뺀다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (12, '접시에 데친 브로콜리와 컬리플라워, 삶은 강낭콩, 채썬 적양파, 다진 호두, 건포도를 담고 두유요거트 소스를 곁들여 낸다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (12, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00094_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (12, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00094_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (12, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00094_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (13, 1, '오렌지와 당근 만남주스', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00108_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '시판되는 대부분의 주스는 가공되고 농축되는 과정에서 나트륨이 첨가되는 경우가 있어 과일, 채소를 직접 갈아 마시면 나트륨 섭취를 줄일 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (24, 873, 13);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (25, 268, 13);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (13, '오렌지 당근펀치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (13, '당근', '100g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (13, '오렌지', '100g(1/2개)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (13, '오렌지는 깨끗이 씻어 껍질을 벗긴다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (13, '당근은 깨끗이 씻어 작은 토막으로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (13, '당근, 오렌지, 물(50ml)을 믹서에 곱게 간다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (13, '믹서에 갈아낸 주스는 고운 체로 거른다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (13, '주스를 살얼음이 생길 만큼 시원하게 냉동한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (13, '컵에 담아 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (13, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00108_1.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (13, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00108_2.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (13, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00108_3.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (13, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00108_4.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (13, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00108_5.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (13, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00108_6.jpg');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (14, 1, '칠곡석류국수', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00111_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '견과류에는 불포화 지방산이 풍부하게 함유되어 있어, 고지혈증 등 혈류개선에 효과가 있어 성인병 예방에 좋다. 짠맛을 대신하여 석류의 새콤달콤한 맛을 활용하고, 볶은 견과류로 고소한 맛과 풍미를 더하였다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (26, 117, 14);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (27, 700, 14);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '주재료 : 소면', '160g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '소스 : 석류', '200g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '장식 : 잣', '4g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '아몬드', '4g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '해바라기씨', '4g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '호두', '4g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '호박씨', '4g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (14, '오이', '20g(1/4개)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (14, '저염소금', '4g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (14, '식초', '8g(1/2작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (14, '잣, 아몬드, 해바라기씨, 호두, 호박씨는 다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (14, '끓는 물에 저염소금과 식초를 넣은 후 소면을 삶은 후 체에 건져 물기를
+뺀다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (14, '석류는 물 600g와 함께 믹서에 갈고 체에 걸러 즙을 낸다. 그릇에 면을 담고 차갑게 식힌 석류즙을 붓고 견과류, 채 썬 오이를 고명으로 올린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (14, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00111_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (14, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00111_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (14, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00111_3.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (15, 1, '블랙빈 곤약국수', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00113_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '검은콩은 안토시아닌 색소를 많이 함유하고 있어 시력회복과 항암작용에 좋다. 나트륨 함량이 높은 소면을 대신하여 실곤약으로 면을 대체함으로써 나트륨과 칼로리의 섭취량을 줄이고, 콩국물에 흑임자와 호두를 넣어 짠맛 대신 고소한 맛과 향을 강조한다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (28, 117, 15);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '주재료', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '실곤약', '440g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '검은콩', '70g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '볶은 흑임자', '6g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '호두', '6g(1알)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '장식', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '오이', '20g(1/8개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '토마토', '50g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (15, '달걀', '50g(1개)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (15, '검은콩을 1시간 찬물에 담가 불린 후 삶아 익힌 후 불순물을 제거하고 흑임자, 생수, 삶은 콩, 호두를 믹서에 갈아 살엄음이 생기도록 냉동실에 넣는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (15, '오이는 돌려 깎아 채 썰고, 토마토는 1/8크기로 썰고, 달걀은 삶아 반으로 자른다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (15, '실곤약은 끓는 물에 데치고 찬물에 헹궈 그릇에 담은 후 콩물을 담고 오이, 토마토, 달걀을 고명으로 올려 완성한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (15, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00113_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (15, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00113_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (15, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00113_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (16, 1, '닭가슴살 브로콜리 만두', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00114_1.png', '찌기', '염증감소', '한식', '보통', 0, 0, '칼륨 함량이 높은 브로콜리를 사용하여 나트륨 배출을 돕는다. 만두소는 저염간장으로 양념하고 별도로 초간장을 곁들이지 않아 나트륨섭취를 줄인다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (29, 639, 16);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (16, '만두피', '4g(2장)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (16, '브로콜리', '100g(1/4개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (16, '숙주', '100g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (16, '표고버섯', '20g(2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (16, '닭 가슴살', '100g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (16, '후춧가루', '0.1g');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (16, '참기름', '2g(1/2작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (16, '저염간장', '4g(1작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (16, '소금', '0.5g');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (16, '브로콜리, 숙주, 표고버섯, 닭 가슴살은 다지고 다진 닭 가슴살은 소금과 후추로 밑간 한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (16, '다진 채소와 닭가슴살, 참기름, 저염간장을 섞어 만두소를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (16, '준비한 만두피에 만두소를 넣은 후 만두 모양으로 빚고 만두를 찜통에 넣어 찌고 그릇에 담는다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (16, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00114_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (16, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00114_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (16, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00114_4.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (17, 1, '함초 냉이 국수', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00131_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '냉이에 함유된 비타민A와 비타민C는 소화작용을 용이하게 한다. 소금을 대체하여 함초를 사용하고, 멸치와 모시조개, 다시마 등을 사용하여 감칠맛을 더한다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (30, 117, 17);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (31, 208, 17);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '주재료 : 소면', '50g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '육수 : 함초', '3g(1/2작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '노루궁뎅이버섯', '25g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '다시마', '17g(15cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '무', '250g(1/3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '모시조개', '150g(3/4컵)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '냉이', '35g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '장식 : 달걀', '50g(1개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '청고추', '20g(1개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (17, '실고추', '2g');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (17, '파', '140g(1/2개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (17, '양파', '150g(1/2개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (17, '간장', '30g(2큰술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (17, '함초, 노루궁뎅이버섯, 다시마, 파, 양파, 무를 물에 넣어 10분 끓이고 향이 강한 모시조개와 냉이를 넣고 30분  끓인 후 간장으로 색을 낸다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (17, '소면은 따로 삶는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (17, '그릇에 삶은 소면을 담은 후 육수를 붓고 지단, 슬라이스한 청고추, 실고추를 올려 완성한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (17, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00131_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (17, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00131_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (17, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00131_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (18, 1, '된장 두부찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00137_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '김치는 물에 헹구어 염분을 제거하고 고추를 넣어 매운 맛과 향을 더한다. 두부는 콩 단백질이 풍부한 식품으로 두뇌발달에 좋다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (32, 371, 18);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (33, 375, 18);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (18, '두부', '320g(1모)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (18, '쌀뜨물', '300g(1½컵)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (18, '돼지고기', '100g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (18, '김치', '140g');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (18, '된장', '20g(1½큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (18, '청양고추', '10g(1/2개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (18, '홍고추', '5g(1/4개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (18, '대파', '10g(2cm)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (18, '고춧가루', '5g(1작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (18, '두부에 쌀뜨물을 넣고 갈아준다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (18, '돼지고기는 썰고 김치는 물에 씻어 양념을 제거하고 3×3cm로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (18, '냄비에 돼지고기와 김치를 함께 볶은 후, 망에 거른 된장과 1의 두부, 고춧가루, 청양고추, 홍고추를 넣어 끓이다가 대파를 넣어 완성한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (18, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00137_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (18, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00137_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (18, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00137_3.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (19, 1, '부대된장찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00138_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '저염된장과 저염햄을 사용하고 김치는 물에 헹구어 염도를 낮추어 준다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (34, 371, 19);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '다시마', '1g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '두부', '10g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '떡국 떡', '10g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '스팸', '10g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '무', '20g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '김치', '15g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '소시지', '10g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '우민찌', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (19, '베이컨', '5g');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (19, '다진 마늘', '5g');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (19, '양파', '5g');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (19, '저염된장', '15g(1큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (19, '대파', '5g');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (19, '청양고추', '5g');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (19, '홍고추', '1g');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (19, '김치, 베이컨, 스팸, 소시지, 양파, 두부, 무는 두께 0.5cm로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (19, '다시마와 물을 끓여 다시마물을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (19, '냄비에 소시지, 베이컨, 두부, 스팸, 무, 우민찌, 김치, 다시마물 300g을 넣어 끓인 후 저염된장, 양파, 대파, 다진 마늘, 떡국 떡을 넣고 재료가 다 익으면 홍고추와 청양고추를 넣어 완성한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (19, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00138_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (19, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00138_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (19, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00138_3.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (20, 1, '양배추감자전', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00181_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '감자와 양배추에는 칼륨이 풍부하게 들어있어 나트륨 배출에 도움을 준다. 양념간장 대신 과일즙을 활용한 폰즈소스를 곁들여 나트륨 섭취량을 줄였다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (35, 834, 20);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (36, 44, 20);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (37, 564, 20);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (38, 36, 20);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (39, 560, 20);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '주재료 : 감자', '100g(1개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '양배추', '150g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '당근', '15g(1/10개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '두부', '20g(1/20모)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '돼지고기', '30g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '부침가루', '45g(3큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '달걀', '60g(1개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (20, '소스 : 오렌지즙', '15g(1큰술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (20, '청양고추', '5g(1개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (20, '식용유', '15g(1큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (20, '간장', '2g(1/2작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (20, '식초', '10g(2작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (20, '감자는 믹서에 갈고 양배추는 채 썰고 고기, 당근, 청양고추, 두부는 다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (20, '준비해둔 재료를 모두 섞고 부침가루와 계란을 넣어 반죽한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (20, '가열된 팬에 기름을 두르고 반죽을 부어 굽고 소스를 함께 곁들인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (20, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00181_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (20, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00181_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (20, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00181_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (21, 1, '돌나물 샐러드', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00074_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '샐러드드레싱에 짠맛을 줄이기 위해 마요네즈 사용량을 줄이고 레몬즙과 청양고추를 혼합하여 드레싱을 만들면 짠맛을 줄이는 효과를 낼 수 있어요. 마요네즈 사용이 지나치면 나트륨과 콜레스테롤의 섭취가 높아지므로 주의하세요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (40, 308, 21);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (21, '돌나물 샐러드 : 돌나물', '90g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (21, '미니새송이버섯', '60g(7개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (21, '레몬마요네즈 소스 : 마요네즈', '10g(2작은술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (21, '참기름', '약간');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (21, '레몬즙', '20g(1⅓큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (21, '청양고추', '5g(1/2개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (21, '홍고추', '5g(1/2개)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (21, '청양고추와 홍고추를 다져서 참기름에 살짝 볶은 후 볶은 고추에 마요네즈와 레몬즙을 넣어 소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (21, '돌나물은 손질하여 찬물에 담구고 새송이버섯은 달군 프라이팬에 참기름을 두르고 노릇
+하게 굽는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (21, '돌나물은 물기를 빼고 구운 새송이버섯과 레몬마요네즈 소스를 넣고
+버무려 접시에 담는다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (21, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00074_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (21, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00074_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (21, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00074_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (22, 1, '석류 보쌈김치', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00159_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '배추는 최소한의 소금으로 절이고 석류 즙으로 새콤한 맛과 향을 더한다. 미네랄, 칼슘, 무기질이 풍부한 석류는 여성질환에 도움을 준다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (41, 700, 22);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (42, 163, 22);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (22, '주재료 : 배추', '70g(1/10개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (22, '석류즙', '10g(2작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (22, '양념 : 무', '10g(3cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (22, '미나리', '10g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (22, '다진 생강', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (22, '새우젓국', '15g(1큰술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (22, '소금', '5g(1/2작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (22, '쪽파', '10g(1개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (22, '다진 마늘', '5g(1작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (22, '배추를 소금물에 하루 동안 절인 후 물기를 빼고 석류는 즙을 낸다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (22, '무는 채 썰고, 쪽파와 미나리는 4cm로 자른다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (22, '무채, 미나리, 쪽파, 다진 마늘, 다진 생강, 새우젓국을 넣고 섞어 소를 만들고 절인 배추에 소를 넣고 오므려 싼다. 석류즙에 소를 채운 배추를 담가 완성한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (22, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00159_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (22, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00159_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (22, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00159_4.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (23, 1, '유자 대구조림', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00161_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '소스에 유자청으로 향을 더하고 발사믹식초로 상큼함을 더한다. 찜은 재료 본연의 맛을 느낄 수 있는 조리법이며 소스를 찍어먹을 수 있도록 곁들여 내면 나트륨 섭취량을 줄일 수 있다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (43, 272, 23);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (44, 919, 23);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (45, 989, 23);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '주재료 : 대구살', '120g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '홍파프리카', '10g(1/10개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '황파프리카', '10g(1/10개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '청파프리카', '10g(1/10개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '황금팽이버섯', '10g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '미나리', '20g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '밀가루', '25g(2큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '소스 : 유자청', '20g(1⅓큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '화이트와인', '10g(2작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (23, '장식 : 대파', '30g(1개)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (23, '발사믹식초', '10g(2작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (23, '발사믹 식초, 화이트와인, 다진 유자청 건더기를 넣고 졸여 소스를 만들고 대구를 손질하여 포를 뜬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (23, '대파, 청파프리카, 홍파프리카, 황파프리카를 채 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (23, '대구포에 밀가루를 묻혀 청파프리카, 홍파프리카, 황파프리카, 황금팽이버섯을 넣고 말아 미나리로 묶어 찐 후 소스를 뿌리고 썬 대파를 올려 완성한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (23, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00161_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (23, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00161_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (23, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00161_4.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (24, 1, '파프리카 물김치', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00162_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '김치를 절인 후 찬물에 세 번 씻어 소금기를 빼고 기호에 따라 청고추를 넣어 매콤한 맛을 준다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (46, 1159, 24);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (47, 504, 24);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (48, 163, 24);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (49, 1150, 24);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '주재료 : 자색고구마', '10g(3cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '무', '10g(2cm)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '배', '80g(1/4개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '배추', '200g(1/3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '부추', '10g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '사과', '80g(1/3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '양념 : 멥쌀', '10g(2작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (24, '황파프리카', '140g(1½개)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (24, '쪽파', '10g(10cm)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (24, '소금', '20g(1⅓큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (24, '물엿', '50g(1/4컵)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (24, '황파프리카를 갈아 체에 내리고 멥쌀로 쌀풀을 만들어 황파프리카 즙을 섞고 물엿을 첨가하여 양념을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (24, '배추를 소금물에 절이고 절인 배추를 찬물로 씻어 소금기를 뺀다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (24, '소금기를 뺀 배추에 채썬 자색고구마, 무, 쪽파, 부추, 사과, 배를 놓고 양념을 부은 후 3일 동안 숙성시켜 완성한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (24, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00162_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (24, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00162_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (24, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00162_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (25, 1, '고추장 라따뚜이', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00193_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '칼륨이 풍부한 토마토를 사용하여 나트륨 배출에 도움을 주며, 살라미는 끓는 물에 데쳐 염분을 제거한 후 사용한다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (50, 91, 25);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (51, 88, 25);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '주재료 : 애호박', '70g(1½개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '양송이버섯', '60g(3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '가지', '70g(1/2개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '저염살라미', '25g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '사과', '60g(1/3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '소스 :양파', '40g(1/5개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '토마토', '600g(3개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (25, '바질', '50g');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (25, '마늘', '10g(2개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (25, '설탕', '10g(2작은술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (25, '고추장', '15g(1큰술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (25, '양파와 마늘은 다져서 볶다가 토마토 과육과 설탕, 바질을 넣고 고추장을 섞어 토마토 소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (25, '가지, 양송이버섯, 애호박, 사과는 썰고 살라미는 데친다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (25, '오븐용 팬에 토마토 소스를 넓게 펴준 뒤 애호박, 가지, 양송이버섯, 살라미를 겹치게 넣고 180℃로 예열한 오븐에 넣고 30분 구워 완성한다');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (25, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00193_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (25, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00193_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (25, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00193_3.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (26, 1, '민들레 샐러드', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00201_1.png', '기타', '염증감소', '한식', '보통', 0, 0, '간장에 생수를 희석하여 염도를 낮추고 레몬의 상큼함을 강조한다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (52, 518, 26);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (26, '주재료 : 민들레 잎', '40g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (26, '비트', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (26, '오렌지', '40g(1/5개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (26, '드레싱 : 간장', '20g(1⅓큰술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (26, '다진 홍고추', '10g(1개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (26, '레몬즙', '60g(4큰술)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (26, '설탕', '6g(1작은술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (26, '간장, 레몬즙, 설탕, 다진 홍고추를 섞어 드레싱을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (26, '민들레 잎은 4×4cm로 썰고, 비트는 채 썰고 물에 담가 색을 뺀다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (26, '오렌지는 씻어 껍질만 발라 채 썰고 민들레 잎, 비트, 오렌지 껍질을 섞어 접시에 담고 드레싱을 곁들인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (26, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00201_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (26, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00201_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (26, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00201_4.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (27, 1, '토마토 가지 카프레제', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00202_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '칼륨 함량이 높은 토마토와 가지 사용하여 나트륨의 배출을 돕고, 가지와 토마토의 영양성분 중 베타카로틴은 시력보호와 피부노화에 효과가 있다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (53, 1139, 27);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (54, 17, 27);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (55, 412, 27);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (27, '주재료 : 가지', '100g(1개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (27, '토마토', '200g(1½개)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (27, '무순', '20g');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (27, '올리브오일', '5g(1작은술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (27, '드레싱 : 올리브오일', '25g(2큰술)');
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (27, '후춧가루', '2g(1/2작은술)');
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (27, '마늘', '10g(2개)');
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (27, '발사믹식초', '60g(4큰술)');
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (27, '올리브오일, 발사믹식초, 후춧가루를 섞어 차게 식혀 드레싱을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (27, '가지와 토마토는 5mm두께로 썰고 120도 오븐에 20분 구운 후 구운 가지는 물기를 제거한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (27, '팬에 올리브오일을 두르고 약불에서 채 썬 마늘을 볶다가, 가지를 넣고 구운 후 접시에 토마토, 가지를 번갈아 담고 무순으로 장식하고 드레싱을 곁들인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (27, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00202_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (27, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00202_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (27, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00202_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (28, 1, '우렁된장소스 배추롤', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00636_1.png', '찌기', '염증감소', '한식', '보통', 0, 0, '된장에 양파, 당근, 호박, 표고버섯을 많이 섞어 나트륨 함량을 감소시키고, 야채맛이 가득한 된장소스를 만들 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (56, 371, 28);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (57, 564, 28);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (58, 560, 28);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '돼지고기', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '배춧잎', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '부추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '쌀', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '당근', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '표고버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '애호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (28, '우렁이', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (28, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (28, '된장', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (28, '끓는 물에 배춧잎을 데친다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (28, '당근, 호박, 표고버섯, 양파는
+입자있게 다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (28, '돼지고기를 썰어 불린 쌀, 다진 야채와
+함께 밥을 짓는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (28, '데친 배춧잎에 지어놓은 밥을 올려
+돌돌만다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (28, '말아 놓은 배춧잎을 부추로 묶는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (28, '찜통에 김이 오르면 ?번을 넣고 약 5분
+정도 찐다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (28, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00636_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (28, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00636_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (28, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00636_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (28, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00636_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (28, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00636_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (28, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00636_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (29, 1, '인삼떡갈비', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00637_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '대추의 단맛 때문에 간장을 적게 쓸 수 있어 나트륨을 줄일 수 있어요', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (59, 933, 29);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (60, 392, 29);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '소고기', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '돼지고기', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '대추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '배', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '애호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '단호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '파프리카', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '인삼', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '양송이', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '배추잎', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '후춧가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (29, '두부', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (29, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (29, '마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (29, '저염간장', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (29, '설탕', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (29, '소금', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (29, '대추는 돌려 깍아 씨를 제거 하고 곱게
+다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (29, '다진 소고기와 돼지고기에 대추와 소금
+후춧가루를 넣고 치댄다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (29, '애호박과 단호박, 파프리카는
+입자있게 썰어 ?에 넣고 잘 치댄다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (29, '양송이는 편으로 썰어 팬에 익히고,
+인삼을 뇌두를 자르고 깨끗이 씻어
+팬에 볶아 잘게 썰어 ?에 넣는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (29, '재료가 골고루 섞인 떡갈비를 갈비
+모양으로 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (29, '떡갈비를 팬에 굽고, 접시에 배춧잎을
+깔고 익힌 양송이를 올리고 떡갈비를
+담는다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (29, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00637_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (29, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00637_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (29, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00637_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (29, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00637_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (29, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00637_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (29, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00637_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (30, 1, '초계탕과 사색곤약', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00638_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '다시마와 건새우의 천연 조미료 성분이 나트륨을 대신할 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '닭고기', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '가시오가피', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '건새우', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '실곤약', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '비트', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '치자가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '후춧가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '오이', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (30, '겨자가루', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (30, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (30, '마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (30, '소금', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (30, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (30, '식초', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (30, '설탕', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (30, '닭을 깨끗이 손질하고, 부위별로
+자른다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (30, '냄비에 가시오가피, 대파, 다시마,
+마늘, 건새우를 넣고 은근히 끓인 후
+닭을 넣고 약 20분 정도 삶아 건진 뒤
+살을 찢어둔다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (30, '양파, 오이는 채썰고 식초, 설탕,
+소금을 넣고 초절임한다');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (30, '겨자가루에 30℃ 정도의 물을 넣고
+골고루 섞어 발효시키고, 설탕, 식초,
+소금을 넣고 겨자소스를 만든다');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (30, '흰곤약과 비트, 치자가루를 섞은 곤약,
+채썬 다시마를 접시에 담는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (30, '양파, 오이 초절임과 닭살을 한쪽에
+담아 먹기 직전에 겨자소스를 올린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (30, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00638_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (30, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00638_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (30, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00638_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (30, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00638_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (30, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00638_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (30, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00638_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (31, 1, '호박잎 삼계탕', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00639_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '소화가 잘되는 찹쌀을 사용하여 쫀득한 맛을 낼 수 있으며, 별도 소스없이 고소한 맛을 즐길 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (61, 1212, 31);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (62, 543, 31);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '호박잎', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '닭고기(가슴살', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '120g)', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '찹쌀', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '대추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '미나리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '인삼', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (31, '후춧가루', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (31, '소금', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (31, '찹쌀은 깨끗이 씻어 30분 정도 불린다');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (31, '불린 찹쌀은 냄비에 넣고 질게 밥을
+한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (31, '닭가슴살은 넓게 펴서 소금,
+후춧가루를 뿌린다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (31, '호박잎과 미나리는 끓는 물에 살짝
+데치고, 대추는 돌려 깎아 씨를
+제거하고 인삼은 뇌두를 제거한 뒤
+채를 썰어둔다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (31, '데친 호박잎에 닭 가슴살을 올린다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (31, '닭 가슴살위에 찹쌀밥과 준비한 야채와
+대추를 올려 돌돌 말아 질게 된
+찹쌀밥에 넣고 약 20분 정도 더 쪄낸다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (31, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00639_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (31, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00639_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (31, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00639_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (31, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00639_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (31, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00639_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (31, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00639_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (32, 1, '황태미역 곤약스프', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00640_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '된장에 두부를 섞어서 나트륨을 감소시킬 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (63, 515, 32);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (32, '황태채', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (32, '곤약', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (32, '건미역', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (32, '들깨가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (32, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (32, '표고버섯', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (32, '된장', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (32, '액젓', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (32, '마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (32, '참기름', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (32, '된장에 두부를 넣고 골고루 섞는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (32, '표고버섯과 마늘은 함께 갈아둔다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (32, '미역은 충분히 불린다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (32, '냄비에 황태채와 갈아둔 표고버섯,
+마늘을 넣고 은근히 끓여 육수를
+만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (32, '곤약은 납작납작하게 썰어 끓는 물에
+데친다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (32, '육수에서 황태를 건져 두부된장과 함께
+갈아 육수에 붓고, 미역, 곤약,
+들깨가루를 넣고 약 20분 정도 끓인 후
+액젓으로 간을 한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (32, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00640_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (32, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00640_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (32, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00640_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (32, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00640_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (32, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00640_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (32, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00640_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (33, 1, '훈제오리가슴살 샐러드', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00641_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '훈제오리와 양파채 및 레디쉬채와 블루베리를 함께 먹으면 나트륨 섭취도 감소시켜주고 훈제오리의 맛을 한층 더 좋게 만들어요', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (33, '오리고기(훈제오리 가슴살', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (33, '150g)', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (33, '발사믹소스', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (33, '파슬리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (33, '블루베리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (33, '레디쉬', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (33, '양파', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (33, '훈제오리 가슴살을 슬라이스한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (33, '슬라이스한 훈제오리는 팬에 굽는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (33, '양파는 채썰고 찬물에 담근 뒤 건진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (33, '레디쉬는 채썰고 찬물에 담근 뒤
+건진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (33, '먹기 직전에 발사믹소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (33, '접시에 훈제오리와 양파채, 레디쉬,
+블루베리를 담고 발사믹소스를
+올린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (33, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00641_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (33, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00641_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (33, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00641_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (33, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00641_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (33, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00641_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (33, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00641_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (34, 1, '훈제오리가슴살크러스트', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00642_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '로즈마리를 사용하여 오리고기의 잡내를 제거하고, 유자청을 이용한 소스는 소금을 적게 사용해도 맛을 좋게 만들어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '오리고기(훈제오리 가슴살', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '150g)', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '로즈마리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '오렌지', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '새송이버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '파슬리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '땅콩', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '올리브오일', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '유자청', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (34, '후춧가루(0.5g', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (34, '훈제오리 가슴살은 올리브오일,
+로즈마리, 후춧가루로
+마리네이드한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (34, '새송이버섯은 편으로 썰고 팬에
+굽는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (34, '오렌지는 슬라이스로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (34, '땅콩과 파슬리는 입자있게 다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (34, '마리네이드한 오리 고기를 구워 접시에
+담는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (34, '유자청에 땅콩, 파슬리가루를 넣고
+소스를 만들고, 구워진 오리고기
+사이에 오렌지 슬라이스를 넣고
+유자청소스를 올린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (34, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00642_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (34, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00642_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (34, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00642_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (34, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00642_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (34, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00642_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (34, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00642_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (35, 1, '간장소스를 곁들인 새우전복찜', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00643_1.png', '찌기', '염증감소', '한식', '보통', 0, 0, '해초류를 사용해서 소금을 대신할 수 있어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (64, 24, 35);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (65, 693, 35);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (66, 969, 35);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (35, '전복', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (35, '새우', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (35, '시금치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (35, '해초', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (35, '레몬', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (35, '녹말', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (35, '식용꽃', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (35, '저염간장', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (35, '설탕', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (35, '소금', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (35, '마늘', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (35, '전복은 수저로 떼어내어 소금으로 비벼
+깨끗이 씻는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (35, '시금치는 데쳐 다지고, 새우는 껍질을
+벗겨 전복, 해초와 함께 다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (35, '?번을 잘 섞어 전복 껍질에 넣는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (35, '찜통에 김이 오르면 속을 채운 전복
+껍질을 넣고 약 10분 정도 찐다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (35, '저염간장, 레몬, 설탕, 다진마늘을
+넣고 살짝 끓여 소스를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (35, '간장소스에 전분을 풀어 농도를
+맞추고, 전복찜에 여러번 바르고
+식용꽃을 올린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (35, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00643_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (35, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00643_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (35, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00643_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (35, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00643_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (35, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00643_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (35, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00643_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (36, 1, '검은콩국수', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00644_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '블랙푸드의 대표 주자인 검은콩으로 만들어 나트륨 함량을 줄일 수 있었어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (67, 117, 36);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (36, '검은콩', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (36, '메밀면', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (36, '오이', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (36, '방울토마토', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (36, '땅콩', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (36, '잣', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (36, '참깨', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (36, '검은콩은 깨끗이 씻어 약 12시간 정도
+충분히 불린다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (36, '불린 검은콩은 20분 정도 삶아 깨끗이
+씻는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (36, '삶은 검은콩은 믹서기에 곱게 갈아
+차갑게 식힌다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (36, '오이는 씨를 제거하고 깨끗이 씻어
+채썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (36, '물을 끓여 메밀면을 삶고, 찬물에
+여러번 헹구어 건져 물기를 뺀다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (36, '메밀면을 그릇에 담고 차가운 콩 국물,
+땅콩, 잣, 오이, 방울토마토 및 통깨를
+올린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (36, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00644_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (36, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00644_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (36, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00644_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (36, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00644_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (36, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00644_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (36, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00644_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (37, 1, '겨자소스로 구운 산마샐러드', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00645_1.png', '굽기', '염증감소', '한식', '보통', 0, 0, '참나물, 돈나물의 칼륨 성분이 체내에 쌓인 나트륨을 배출을 도와줘요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (68, 71, 37);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (69, 412, 37);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (37, '산마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (37, '참나물', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (37, '돈나물', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (37, '토마토', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (37, '레디쉬', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (37, '어린잎', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (37, '겨자가루.', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (37, '저염간장', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (37, '식초', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (37, '설탕', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (37, '어린잎은 찬물에 담근다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (37, '마는 껍질을 벗겨 동글동글하게 썬다');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (37, '썰어 놓은 마는 팬에 기름을 살짝
+두르고 앞뒤로 굽는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (37, '참나물, 돈나물, 토마토, 레디쉬는
+먹기 좋은 크기로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (37, '겨자가루는 30℃ 물을 섞어 발효
+시킨다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (37, '저염간장에 식초, 설탕, 발효겨자를
+넣고 골고루 섞어 소스를 만들고,
+접시에 구운 마와 손질한 야채를 넣고
+만들어 놓은 소스와 어린잎을 올린다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (37, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00645_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (37, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00645_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (37, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00645_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (37, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00645_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (37, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00645_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (37, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00645_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (38, 1, '닭고기김치찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00271_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '멸치다시마육수를 이용해 깊은 맛을 내 소금간을 줄여
+나트륨 섭취를 적게 할 수 있고, 달걀물을 부어 자극적인 맛을 줄였다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (70, 253, 38);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (71, 163, 38);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '닭가슴살', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '애호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '미나리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '김치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '느타리버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '달걀', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '육수 다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '무', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '마른 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '멸치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (38, '물', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (38, '청양고추', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (38, '참기름', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (38, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (38, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (38, '마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (38, '청주', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (38, '육수 재료를 넣고 중간 불로 끓인 뒤
+체에 걸러 육수를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (38, '닭가슴살은 채 썬 뒤 물에 넣고
+삶는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (38, '애호박은 반달 썰고, 미나리는 5㎝
+길이로 썰고, 청양고추는 잘게 썬 뒤
+찬물에 담가 씨를 빼고, 두부는 한입
+크기로 썰어 물에 담가둔다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (38, '김치를 한입 크기로 썬 뒤 참기름에
+볶다가 육수를 붓는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (38, '두부, 애호박, 느타리버섯, 미나리,
+닭가슴살을 넣어 끓어오르면
+달걀물과 청양고추를 넣고 조금
+더 끓여 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (38, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00271_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (38, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00271_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (38, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00271_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (38, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00271_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (38, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00271_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (39, 1, '완자김치찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00272_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '김치는 물에 한 번 씻어 염분을 최대한 제거하고,
+쇠고기육수로 깊은 맛을 내고 붉은 고추로 매콤한 맛을 더해
+소금간을 하지 않아 나트륨 섭취를 줄였다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (72, 163, 39);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '콩나물', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '김치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '붉은 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '다진 돼지고기(등심', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '60g)', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '육수 대파', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (39, '쇠고기', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (39, '새우젓', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (39, '마늘', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (39, '대파, 마늘, 쇠고기를 물(300g)과
+함께 끓인 뒤 면포에 걸러 육수를
+만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (39, '콩나물, 김치를 물에 씻어 손질한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (39, '두부는 물기를 빼고, 붉은 고추는
+다진 뒤 돼지고기와 섞어 반죽해
+동그랗게 빚어 완자를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (39, '김 오른 찜기에 완자를 넣어 찐다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (39, '육수를 끓이고 끓어오르면 김치,
+콩나물, 새우젓을 넣는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (39, '한소끔 더 끓이다가 완자를 넣고
+조금 더 끓여 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (39, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00272_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (39, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00272_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (39, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00272_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (39, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00272_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (39, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00272_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (39, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00272_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (40, 1, '백김치콩비지찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00273_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '콩비지찌개를 끓일 때 넣는 묵은지 대신
+백김치를 넣어 염분을 줄이고 깔끔한 맛을 냈다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (73, 163, 40);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (40, '풋고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (40, '백김치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (40, '콩비지', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (40, '후춧가루', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (40, '참기름', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (40, '다진 마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (40, '간장', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (40, '풋고추는 잘게 다진다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (40, '백김치는 먹기 좋은 크기로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (40, '냄비에 백김치를 볶다가 김치가
+익으면 참기름, 후춧가루,
+다진 마늘을 넣고 볶는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (40, '물(200g)을 넣고 끓인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (40, '물이 끓으면 콩비지와 간장,
+풋고추를 넣어 약한 불에서 15분
+정도 끓여 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (40, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00273_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (40, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00273_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (40, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00273_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (40, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00273_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (40, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00273_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (41, 1, '오징어김치찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00274_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '김치의 속을 덜어내 염분을 줄였고,
+김치 자체의 간만을 이용해 나트륨 섭취량을 줄였다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (74, 881, 41);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (75, 163, 41);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '오징어', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '팽이버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '붉은 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '고구마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '콩나물', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '김치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '쑥갓', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '육수 무', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '멸치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '물', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (41, '들깻가루', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (41, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (41, '참기름', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (41, '육수 재료를 넣고 끓인 뒤 체로 걸러
+육수를 낸다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (41, '오징어 몸통은 큼지막하게 썰고
+다리는 얇게 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (41, '두부와 버섯은 먹기 좋게 썰고,
+고추는 어슷하게 썰고, 고구마는
+먹기 좋은 크기로 썰고, 콩나물은
+다듬는다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (41, '김치는 먹기 좋은 크기로 썬 뒤
+냄비에 참기름을 두르고 볶다가
+고구마, 콩나물, 육수를 넣고 끓인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (41, '자작하게 끓으면 오징어를 넣고
+끓이고, 오징어가 익으면 들깻가루를
+넣고 끓인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (41, '두부, 팽이버섯, 쑥갓, 고구마,
+붉은 고추를 넣고 끓여 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (41, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00274_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (41, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00274_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (41, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00274_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (41, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00274_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (41, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00274_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (41, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00274_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (42, 1, '해물김치찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/20230313/20230313110520_1678673120064.jpg', '끓이기', '염증감소', '한식', '보통', 0, 0, '•김치는 국물을 꼭 짜서 사용해 염분을 줄였고, 해산물을 넣어 간을 맞췄어요.
+•배즙으로 짠맛을 중화하면서 나트륨 함량을 줄였어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (76, 504, 42);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (77, 163, 42);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '필수 재료 : 주꾸미', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '김치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '무', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '배즙', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '팽이버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '육수 재료 : 다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '멸치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (42, '물', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (42, '마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (42, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (42, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (42, '참기름', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (42, '냄비에 육수 재료를 넣고 끓이다가 물이 끓어오르면 다시마를 건지고 조금 더 끓여 육수를 우려낸다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (42, '주꾸미는 내장과 입, 눈을 제거하고 4cm 크기로 잘라 준비한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (42, '김치는 국물을 꽉 짜서 한입 크기로 썰고, 무는 편 썰고, 마늘은 다지고, 대파는 어슷 썰고, 양파는 굵게 채 썰고, 두부는 납작하게 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (42, '냄비에 참기름을 두르고, 김치, 무, 양파가 투명해질 때까지 볶다가 육수를 붓고 끓으면 주꾸미, 다진 마늘을 넣어 더 끓인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (42, '김칫국물과 배즙을 2:1로 섞은 뒤 찌개에 넣어 간을 맞춘다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (42, '두부, 팽이버섯을 넣고 한소끔 끓여 마무리한다');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (42, 'http://www.foodsafetykorea.go.kr/uploadimg/20230306/20230306022942_1678080582607.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (42, 'http://www.foodsafetykorea.go.kr/uploadimg/20230306/20230306023039_1678080639676.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (42, 'http://www.foodsafetykorea.go.kr/uploadimg/20230306/20230306023103_1678080663820.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (42, 'http://www.foodsafetykorea.go.kr/uploadimg/20230313/20230313110637_1678673197807.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (42, 'http://www.foodsafetykorea.go.kr/uploadimg/20230306/20230306023149_1678080709863.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (42, 'http://www.foodsafetykorea.go.kr/uploadimg/20230306/20230306023210_1678080730863.jpg');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (43, 1, '맑은부대찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00276_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '보통 부대찌개에 들어가는 김치와 햄 대신
+배추와 고기완자를 넣어 나트륨 함량을 줄였다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '느타리버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '콩나물', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '배추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '미나리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '돼지고기', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '쇠고기', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '불린 당면', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '조랭이떡', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '다시마육수 다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '무', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '마른 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '고기완자양념 생강즙', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '다진 파', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '후춧가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (43, '소금(0.1g', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (43, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (43, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (43, '다진 마늘', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (43, '다시마육수재료를 물에 넣고 끓여
+육수를 낸다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (43, '느타리버섯은 가닥가닥 떼고, 두부는
+썰고, 콩나물은 머리와 꼬리를 떼
+손질한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (43, '배추와 미나리를 데친다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (43, '돼지고기, 쇠고기에 고기완자양념을
+넣어 반죽한 뒤 빚어 완자를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (43, '냄비에 모든 재료를 돌려 담은 뒤
+육수를 부어 끓인다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (43, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00276_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (43, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00276_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (43, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00276_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (43, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00276_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (43, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00276_5.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (44, 1, '나가사키부대찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00277_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '나트륨 함량이 높은 김치와 고추장 대신 사골육수와 청양고추를 사용해
+염도를 낮추면서 칼칼하고 깔끔한 맛을 내 나트륨 섭취를 줄였다', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '통조림 햄', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '우유', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '실곤약', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '느타리버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '표고버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '팽이버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '붉은 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '감자', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '무', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '애호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '깻잎', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '쑥갓', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '완자 다진 돼지고기', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '다진 파', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '후춧가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '밀가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '달걀노른자', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '육수 사골육수', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (44, '들깻가루', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (44, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (44, '청양고추', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (44, '다진 마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (44, '소금', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (44, '통조림 햄은 한 번 데친 뒤 우유에
+담가두고, 실곤약은 식초를 넣은
+끓는 물에 살짝 데친다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (44, '양파는 굵게 채 썰고, 느타리버섯은
+찢고, 표고버섯은 모양대로 썰고,
+팽이버섯은 끝부분을 잘라내고,
+청양고추와 붉은 고추는 어슷 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (44, '감자, 무, 두부는 0.5㎝ 두께로 썰고,
+애호박은 반달썰기 하고 깻잎은
+채 썰어 찬물에 담가 매운맛을
+제거한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (44, '사골육수에 다시마를 넣어 끓인 후
+한 김 식힌다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (44, '다진 돼지고기에 다진 파, 다진 마늘,
+후춧가루, 소금을 섞어 완자를
+만들고 밀가루와 달걀물을 묻혀
+식용유(5g)를 두른 팬에 부친다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (44, '냄비에 재료를 보기 좋게 담고
+사골육수를 부은 뒤 끓이다가
+쑥갓과 들깻가루를 넣어 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (44, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00277_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (44, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00277_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (44, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00277_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (44, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00277_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (44, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00277_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (44, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00277_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (45, 1, '삼계부대찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00278_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '양념장에 고추장 대신 겨자가루와 콩가루로 간을 하여 나트륨 사용을 줄였다', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '닭가슴살', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '당근', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '붉은 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '풋고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '쑥갓', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '표고버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '애호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '김치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '팽이버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '당면', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '숙주', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '떡', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '육수 당귀', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '대추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '오가피', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '함초', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '양념장 겨자가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '콩가루', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (45, '쌀겨', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (45, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (45, '고춧가루', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (45, '다진 마늘', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (45, '육수 재료를 넣고 20분간 끓여
+육수를 낸다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (45, '닭가슴살과 당근을 다져 모양을
+잡은 뒤 김 오른 찜기에 넣고 찐다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (45, '고추, 대파는 어슷 썰고, 쑥갓,
+표고버섯, 애호박, 김치는 먹기
+좋은 크기로 썰고, 팽이버섯은
+밑동을 잘라 손질한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (45, '당면과 숙주는 뜨거운 물에 데쳐
+준비한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (45, '양념장 재료를 섞은 뒤 육수(13g)를
+넣고 양념장을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (45, '준비한 재료를 담고 육수를 부은 뒤
+양념장을 넣고 끓여 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (45, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00278_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (45, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00278_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (45, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00278_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (45, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00278_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (45, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00278_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (45, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00278_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (46, 1, '쑥갓부대찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/20230308/20230308012559_1678249559785.jpg', '끓이기', '염증감소', '한식', '보통', 0, 0, '•김치는 씻어서 사용하고 햄은 한 번 데쳐 나트륨 함량을 낮췄어요.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (78, 791, 46);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (79, 46, 46);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (80, 789, 46);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '필수재료 : 통조림 햄', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '애호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '팽이버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '김치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '쑥갓', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '육수 : 다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '물', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '양념장 : 설탕', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (46, '다진마늘', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (46, '청양고추', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (46, '고춧가루', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (46, '고추장', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (46, '통조림 햄을 썰어 끓는 물에 데친다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (46, '애호박은 반달모양으로 썰고, 두부는 도톰하게 썰고, 팽이버섯은 3등분하고, 청양고추는 어슷 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (46, '김치는 씻어서 잘게 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (46, '양념장을 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (46, '냄비에 물과 다시마를 넣고 살짝 끓여 육수를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (46, '육수에 손질한 재료를 담고 양념장의 1/2 분량을 넣고 중간 불에 끓이다가 쑥갓과 남은 양념장을 넣고 약한 불에 조금 더 끓여 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (46, 'http://www.foodsafetykorea.go.kr/uploadimg/20230308/20230308012641_1678249601913.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (46, 'http://www.foodsafetykorea.go.kr/uploadimg/20230308/20230308012702_1678249622285.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (46, 'http://www.foodsafetykorea.go.kr/uploadimg/20230308/20230308012717_1678249637881.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (46, 'http://www.foodsafetykorea.go.kr/uploadimg/20230308/20230308012732_1678249652118.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (46, 'http://www.foodsafetykorea.go.kr/uploadimg/20230308/20230308012747_1678249667092.jpg');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (46, 'http://www.foodsafetykorea.go.kr/uploadimg/20230308/20230308012805_1678249685798.jpg');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (47, 1, '들깨순두부찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00280_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '보통 순두부찌개에 넣는 고춧가루를 넣지 않고
+들깻가루와 들깨를 넣어 고소한 맛을 내 나트륨 섭취를 줄였다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (81, 375, 47);
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (82, 385, 47);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '굴', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '멸치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '표고버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '느타리버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '무', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '미나리', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '붉은 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '순두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (47, '들깻가루', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (47, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (47, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (47, '다진 마늘', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (47, '국간장', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (47, '소금', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (47, '굴은 깨끗이 씻은 뒤 김 오른 찜기에
+찐다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (47, '굴을 쪄낸 물(250g)에 멸치,
+표고버섯 밑동을 넣고 끓인 뒤
+멸치와 표고버섯 밑동을 건져내
+육수를 만든다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (47, '느타리버섯은 밑동을 제거한 후
+씻어 세로로 찢고, 표고버섯은
+0.5㎝ 두께로 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (47, '무는 나박 썰고 양파는 채 썰고,
+미나리는 3㎝ 길이로 썰고,
+대파와 고추는 송송 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (47, '육수에 굴, 다진 마늘, 무, 양파,
+버섯을 넣고 끓인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (47, '들깻가루와 순두부를 넣고 한소끔
+끓인 뒤 국간장과 소금으로 간을
+맞추고 대파, 붉은 고추, 미나리를
+올려 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (47, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00280_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (47, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00280_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (47, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00280_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (47, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00280_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (47, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00280_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (47, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00280_6.png');
+
+INSERT INTO recipe (id, member_id, title, image_url, description, category_slow_aging, category_type, difficulty, time_hours, time_minutes, tips, likes, scraps, created_at, updated_at, allergy_각류, allergy_고등어, allergy_굴, allergy_닭고기, allergy_대두, allergy_돼지고기, allergy_땅콩, allergy_메밀, allergy_밀, allergy_밀류, allergy_복숭아, allergy_쇠고기, allergy_아황산류, allergy_알류, allergy_오징어, allergy_우유, allergy_유제품, allergy_잣, allergy_전복, allergy_조개류, allergy_토마토, allergy_호두, allergy_홍합)
+VALUES (48, 1, '백태순두부찌개', 'http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00281_1.png', '끓이기', '염증감소', '한식', '보통', 0, 0, '매콤한 보통의 순두부찌개와는 달리 백태와 청양고추로
+맛을 내 나트륨 함량을 낮추면서 새우와 바지락으로 감칠맛을 냈다.', 0, 0, '2025-05-11 20:06:31', '2025-05-11 20:06:31', FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE);
+
+INSERT INTO recipe_ingredient (id, ingredient_id, recipe_id) VALUES (83, 375, 48);
+
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '콩(백태', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '30g)', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '느타리버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '표고버섯', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '애호박', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '붉은 고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '풋고추', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '바지락', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '새우', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '순두부', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '육수 마른 다시마', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '멸치', NULL);
+INSERT INTO recipe_ingredients (recipe_id, ingredient_name, ingredient_amount) VALUES (48, '물', NULL);
+
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (48, '양파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (48, '대파', NULL);
+INSERT INTO recipe_seasonings (recipe_id, seasoning_name, seasoning_amount) VALUES (48, '저염된장', NULL);
+
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (48, '냄비에 육수 재료를 넣어 끓인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (48, '콩을 충분히 불려 믹서기에 물을
+넣고 갈아 준비한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (48, '느타리버섯은 찢고, 표고버섯은 먹기
+좋은 크기로 자르고, 애호박과
+양파는 깍둑 썰고, 대파와 고추는
+송송 썬다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (48, '바지락은 해감해 준비한다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (48, '육수에 콩, 느타리버섯, 표고버섯,
+애호박, 저염된장, 새우, 바지락을
+넣고 끊인다.');
+INSERT INTO recipe_step_descriptions (recipe_id, step_descriptions) VALUES (48, '순두부를 넣고 끊인 후 양파, 대파,
+붉은 고추, 풋고추를 넣고 한소끔
+끓여 마무리한다.');
+
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (48, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00281_1.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (48, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00281_2.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (48, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00281_3.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (48, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00281_4.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (48, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00281_5.png');
+INSERT INTO recipe_step_images (recipe_id, step_image_urls) VALUES (48, 'http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00281_6.png');
+


### PR DESCRIPTION
## 📌 Issue Number
- closed https://github.com/SWU-Elixir/Backend/issues/32

## 🪐 작업 내용
- 식품의약품안전처의 공공데이터로부터 요리 레시피 데이터를 받아와 파싱하는 Python 스크립트 작성
- 재료, 양념, 알러지 정보 등을 정제 및 분류하여 SQL로 출력
- '식재료 DB'에 기반한 레시피 식재료 매핑 로직 구현

## ✅ PR 상세 내용
- 다양한 양 표현 처리, 불필요 기호 제거, 정규 표현식 활용 등 포함
- 재료 목록 문자열 파싱 및 재료/양념 분리

## 📚 Reference
- X
