### PR TITLE
feat: 챌린지 최종 완료 여부 조회 API 구현

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
@@ -3,10 +3,7 @@ package BE_Elixir.Elixir.domain.challenge.controller;
 
 import BE_Elixir.Elixir.domain.challenge.controller.api.ChallengeApi;
 import BE_Elixir.Elixir.domain.challenge.dto.request.ChallengeRequestDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeDetailResponseDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeListResponseDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeProgressResponseDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeResponseDTO;
+import BE_Elixir.Elixir.domain.challenge.dto.response.*;
 import BE_Elixir.Elixir.domain.challenge.service.ChallengeAchievementService;
 import BE_Elixir.Elixir.domain.challenge.service.ChallengeService;
 import BE_Elixir.Elixir.domain.member.entity.Member;
@@ -101,5 +98,25 @@ public class ChallengeController implements ChallengeApi {
                             memberDetails.getUsername() + " 사용자의 현재 진행 상황 조회 실패 - " + e.getMessage()));
         }
     }
+
+    // 챌린지 최종 완료 여부 조회
+    @GetMapping("/completion")
+    public ResponseEntity<CommonResponse<ChallengeCompletedResponseDTO>> getChallengeCompletion(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        try {
+            Member member = memberDetails.getMember();
+            ChallengeCompletedResponseDTO dto = challengeAchievementService.getChallengeCompletion(member.getId());
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "챌린지 최종 완료 여부 조회 성공", dto));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "챌린지 최종 완료 여부 조회 실패 - " + e.getMessage()));
+        }
+    }
+
+
 
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/api/ChallengeApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/api/ChallengeApi.java
@@ -1,10 +1,7 @@
 package BE_Elixir.Elixir.domain.challenge.controller.api;
 
 import BE_Elixir.Elixir.domain.challenge.dto.request.ChallengeRequestDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeDetailResponseDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeListResponseDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeProgressResponseDTO;
-import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeResponseDTO;
+import BE_Elixir.Elixir.domain.challenge.dto.response.*;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -110,6 +107,27 @@ public interface ChallengeApi {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     ResponseEntity<CommonResponse<ChallengeProgressResponseDTO>> getProgress(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // 챌린지 최종 완료 여부 조회
+    @Operation(summary = "챌린지 최종 완료 여부 조회", description = "챌린지 최종 완료 여부 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "챌린지 최종 완료 여부 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "챌린지 최종 완료 여부 조회 성공",
+                                      "data": true
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "500", description = "챌린지 최종 완료 여부 조회 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    ResponseEntity<CommonResponse<ChallengeCompletedResponseDTO>> getChallengeCompletion(
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/request/ChallengeRequestDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/request/ChallengeRequestDTO.java
@@ -13,8 +13,8 @@ public class ChallengeRequestDTO {
     private String name;
     private String description;
     private String purpose;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    //private LocalDateTime startDate;
+    //private LocalDateTime endDate;
     private int month;
     private int year;
 
@@ -45,8 +45,8 @@ public class ChallengeRequestDTO {
         challenge.setName(dto.name);
         challenge.setDescription(dto.description);
         challenge.setPurpose(dto.purpose);
-        challenge.setStartDate(dto.startDate);
-        challenge.setEndDate(dto.endDate);
+        //challenge.setStartDate(dto.startDate);
+        //challenge.setEndDate(dto.endDate);
         challenge.setMonth(dto.month);
         challenge.setYear(dto.year);
 

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeCompletedResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeCompletedResponseDTO.java
@@ -1,0 +1,13 @@
+package BE_Elixir.Elixir.domain.challenge.dto.response;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class ChallengeCompletedResponseDTO {
+
+    private String achievementName; // 업적 명
+    private String message; // 메시지
+    private String achievementImageUrl; // 업적 이미지
+    private boolean challengeCompleted; // 챌린지 최종 달성 여부
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeDetailResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeDetailResponseDTO.java
@@ -3,6 +3,7 @@ package BE_Elixir.Elixir.domain.challenge.dto.response;
 import BE_Elixir.Elixir.domain.challenge.entity.Challenge;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -26,11 +27,17 @@ public class ChallengeDetailResponseDTO {
 
     public ChallengeDetailResponseDTO(Challenge challenge, List<String> ingredients) {
         this.name = challenge.getName();
+
+        int year = challenge.getYear();
+        int month = challenge.getMonth();
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
         this.period = String.format("%d월 %d일 ~ %d월 %d일",
-                challenge.getStartDate().getMonthValue(),
-                challenge.getStartDate().getDayOfMonth(),
-                challenge.getEndDate().getMonthValue(),
-                challenge.getEndDate().getDayOfMonth());
+                startDate.getMonthValue(), startDate.getDayOfMonth(),
+                endDate.getMonthValue(), endDate.getDayOfMonth());
+
         this.description = challenge.getDescription();
         this.purpose = challenge.getPurpose();
 

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeResponseDTO.java
@@ -13,8 +13,8 @@ public class ChallengeResponseDTO {
     private String name;
     private String description;
     private String purpose;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    //private LocalDateTime startDate;
+    //private LocalDateTime endDate;
     private int month;
     private int year;
 
@@ -45,8 +45,8 @@ public class ChallengeResponseDTO {
         this.name = challenge.getName();
         this.description = challenge.getDescription();
         this.purpose = challenge.getPurpose();
-        this.startDate = challenge.getStartDate();
-        this.endDate = challenge.getEndDate();
+        //this.startDate = challenge.getStartDate();
+        //this.endDate = challenge.getEndDate();
         this.month = challenge.getMonth();
         this.year = challenge.getYear();
         this.step1Goal1Type = challenge.getStep1Goal1Type();

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/entity/Challenge.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/entity/Challenge.java
@@ -20,8 +20,8 @@ public class Challenge {
     private String name; // 챌린지 명
     private String description; // 챌린지 설명
     private String purpose; // 챌린지 목적
-    private LocalDateTime startDate; // 시작 일시
-    private LocalDateTime endDate; // 끝나는 일시
+    // private LocalDateTime startDate; // 시작 일시
+    // private LocalDateTime endDate; // 끝나는 일시
     private int month; // 월
     private int year; // 년도
 

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/entity/ChallengeAchievement.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/entity/ChallengeAchievement.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.stream.Stream;
 
 @Getter
 @Setter
@@ -48,4 +49,16 @@ public class ChallengeAchievement {
 
     // 챌린지 활성화된 시점 (기록 유효성 판단 기준)
     private LocalDateTime openedAt;
+
+
+    // 캡슐화(챌린지 최종 달성 여부)
+    public boolean isAllGoalsAchieved() {
+        return Stream.of(
+                step1Goal1Achieved, step1Goal2Achieved,
+                step2Goal1Achieved, step2Goal2Achieved,
+                step3Goal1Achieved, step3Goal2Achieved,
+                step4Goal1Achieved, step4Goal2Achieved
+        ).allMatch(Boolean::booleanValue);
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/event/listener/ChallengeEventListener.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/event/listener/ChallengeEventListener.java
@@ -84,10 +84,10 @@ public class ChallengeEventListener {
             return;
         }
 
-        // 해당 챌린지가 열린 시간 (이 시간 이후의 기록만 유효)
+        // 챌린지의 단계 별 세부 목표 열린 시간 (이 시간 이후의 기록만 유효)
         LocalDateTime openedAt = achievement.getOpenedAt();
 
-        // 챌린지 단계별 목표 유형들 (총 8개) 가져오기
+        // 챌린지 단계 별 목표 유형들 (총 8개) 가져오기
         List<ChallengeGoalType> goalTypes = parseGoalTypes(challenge);
 
         // 각 목표의 활성화 상태를 리스트로 구성 (false인 항목은 평가하지 않음)
@@ -119,6 +119,20 @@ public class ChallengeEventListener {
             handleGoal(goalType, memberId, openedAt, resultSetter);
         }
 
+        // 목표 달성 결과에 따라 다음 단계 활성화
+        if (achievement.isStep1Goal1Achieved() && achievement.isStep1Goal2Achieved()) {
+            achievement.setStep2Goal1Active(true);
+            achievement.setStep2Goal2Active(true);
+        }
+        if (achievement.isStep2Goal1Achieved() && achievement.isStep2Goal2Achieved()) {
+            achievement.setStep3Goal1Active(true);
+            achievement.setStep3Goal2Active(true);
+        }
+        if (achievement.isStep3Goal1Achieved() && achievement.isStep3Goal2Achieved()) {
+            achievement.setStep4Goal1Active(true);
+            achievement.setStep4Goal2Active(true);
+        }
+        
         // 서비스에서 달성 정보 저장
         challengeAchievementService.save(achievement);
     }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
@@ -1,10 +1,13 @@
 package BE_Elixir.Elixir.domain.challenge.service;
 
+import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeCompletedResponseDTO;
 import BE_Elixir.Elixir.domain.challenge.dto.response.ChallengeProgressResponseDTO;
 import BE_Elixir.Elixir.domain.challenge.entity.Challenge;
 import BE_Elixir.Elixir.domain.challenge.entity.ChallengeAchievement;
 import BE_Elixir.Elixir.domain.challenge.repository.ChallengeAchievementRepository;
 import BE_Elixir.Elixir.domain.challenge.repository.ChallengeRepository;
+import BE_Elixir.Elixir.global.exception.ErrorCode;
+import BE_Elixir.Elixir.global.exception.OccupiedException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,7 +35,7 @@ public class ChallengeAchievementService {
         ChallengeAchievement achievement = createIfNotExists(memberId);
 
         Challenge challenge = challengeRepository.findById(achievement.getChallengeId())
-                .orElseThrow(() -> new IllegalStateException("챌린지 ID로 챌린지를 찾을 수 없습니다."));
+                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
 
         return ChallengeProgressResponseDTO.from(challenge, achievement);
     }
@@ -46,7 +49,7 @@ public class ChallengeAchievementService {
         // 현재 연도와 월에 해당하는 챌린지 조회
         Challenge challenge = challengeRepository
                 .findByYearAndMonth(year, month)
-                .orElseThrow(() -> new IllegalArgumentException("이번 달의 챌린지를 찾을 수 없습니다."));
+                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
 
         // 해당 챌린지와 회원 ID에 대한 챌린지 달성 정보 조회
         return challengeAchievementRepository
@@ -66,4 +69,39 @@ public class ChallengeAchievementService {
                 });
     }
 
+    // 챌린지 최종 완료 여부 조회
+    @Transactional
+    public ChallengeCompletedResponseDTO getChallengeCompletion(Long memberId) {
+
+        ChallengeAchievement achievement = createIfNotExists(memberId);
+
+        Challenge challenge = challengeRepository.findById(achievement.getChallengeId())
+                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+
+        // 세부 목표 8개 달성 여부
+        boolean allAchieved = achievement.isAllGoalsAchieved();
+
+        if (allAchieved && !achievement.isChallengeCompleted()) {
+            achievement.setChallengeCompleted(true);
+            achievement.setChallengeCompletedAt(LocalDateTime.now());
+            challengeAchievementRepository.save(achievement);
+        }
+
+        if (achievement.isChallengeCompleted()) {
+            return new ChallengeCompletedResponseDTO(
+                    challenge.getAchievementName(),
+                    "챌린지를 완료했습니다!",
+                    challenge.getAchievementImageUrl(),
+                    true
+            );
+        } else {
+            return new ChallengeCompletedResponseDTO(
+                    challenge.getAchievementName(),
+                    "아직 챌린지를 달성하지 못했습니다.",
+                    null,
+                    false
+            );
+        }
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     ALREADY_LIKED(HttpStatus.FORBIDDEN.value(), "이미 좋아요한 레시피입니다."),
     LIKE_NOT_FOUND(HttpStatus.FORBIDDEN.value(), "좋아요한 레시피가 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.FORBIDDEN.value(), "회원이 존재하지 않습니다"),
-    CHALLENGE_NOT_FOUND(HttpStatus.FORBIDDEN.value(), "존재하지 않는 챌린지입니다.");
+    CHALLENGE_NOT_FOUND(HttpStatus.FORBIDDEN.value(), "챌린지를 찾을 수 없습니다."),
+    CHALLENGE_ACHIEVEMENT_NOT_FOUND(HttpStatus.FORBIDDEN.value(), "챌린지 기록이 없습니다.");
     private final int status;
     private final String message;
 }


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/22

## 🪐 작업 내용 - 기능 개발
- 챌린지 최종 완료 여부 조회 API

## ✅ PR 상세 내용
- 챌린지 단계 별 목표 달성 시, 2/3/4단계 달성되지 않는 문제 해결
- 챌린지의 year/month 일관성을 위해 엔티티에 startDate, endDate 필드 삭제

## 📚 Reference
- X