### PR TITLE
feat: 챌린지-마이페이지 관련 기능 개발(로그인한 사용자의 모든 챌린지 업적 조회/달성한 최신 업적 3개 조회)

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/repository/ChallengeAchievementRepository.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/repository/ChallengeAchievementRepository.java
@@ -3,10 +3,14 @@ package BE_Elixir.Elixir.domain.challenge.repository;
 import BE_Elixir.Elixir.domain.challenge.entity.ChallengeAchievement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeAchievementRepository extends JpaRepository<ChallengeAchievement, Long> {
     // 챌린지에 대한 사용자의 달성 상태 정보 조회
     Optional<ChallengeAchievement> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
+
+    // 사용자의 챌린지 달성 정보 조회
+    List<ChallengeAchievement> findByMemberId(Long memberId);
 
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/repository/ChallengeRepository.java
@@ -18,4 +18,8 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     // 연도&달로 현재 챌린지 조회
     Optional<Challenge> findByYearAndMonth(int year, int month);
 
+    // 전체 챌린지 조회 (연도/월 기준)
+    @Query("SELECT c FROM Challenge c ORDER BY c.year ASC, c.month ASC")
+    List<Challenge> findAllOrderedByYearAndMonth();
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -185,4 +185,27 @@ public class MemberController implements MemberApi {
                             "업적 조회 실패 - " + e.getMessage()));
         }
     }
+
+
+    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
+    @GetMapping("/achievement/top3")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        String email = memberDetails.getUsername();
+
+        try {
+            List<MemberAchievementResponseDTO> top3Achievements = memberService.getTop3Achievements(email);
+
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "최근 업적 3개 조회 성공", top3Achievements));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "최근 업적 3개 조회 실패 - " + e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -167,22 +167,6 @@ public class MemberController implements MemberApi {
         }
     }
 
-<<<<<<< HEAD
-    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
-    @GetMapping("/achievement")
-    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
-            @AuthenticationPrincipal MemberDetails memberDetails
-    ) {
-        String email = memberDetails.getUsername();
-
-        try {
-            List<MemberAchievementResponseDTO> achievements = memberService.getAllAchievements(email);
-
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "모든 챌린지 업적 조회 성공", achievements));
-=======
-
     // 팔로우 하기
     @PostMapping("/{targetMemberId}/follow")
     public ResponseEntity<CommonResponse<?>> follow(
@@ -197,32 +181,11 @@ public class MemberController implements MemberApi {
             return ResponseEntity.ok(CommonResponse.success(
                     HttpStatus.OK.value(), HttpStatus.OK.toString(),
                     "팔로우 성공"));
->>>>>>> 6bbd11ebac007ac9446af6469faf129db1413113
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(CommonResponse.error(
                             HttpStatus.INTERNAL_SERVER_ERROR.value(),
                             HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-<<<<<<< HEAD
-                            "업적 조회 실패 - " + e.getMessage()));
-        }
-    }
-
-
-    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
-    @GetMapping("/achievement/top3")
-    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
-            @AuthenticationPrincipal MemberDetails memberDetails
-    ) {
-        String email = memberDetails.getUsername();
-
-        try {
-            List<MemberAchievementResponseDTO> top3Achievements = memberService.getTop3Achievements(email);
-
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "최근 업적 3개 조회 성공", top3Achievements));
-=======
                             "팔로우 실패 - " + e.getMessage()));
         }
     }
@@ -241,15 +204,11 @@ public class MemberController implements MemberApi {
             return ResponseEntity.ok(CommonResponse.success(
                     HttpStatus.OK.value(), HttpStatus.OK.toString(),
                     "언팔로우 성공"));
->>>>>>> 6bbd11ebac007ac9446af6469faf129db1413113
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(CommonResponse.error(
                             HttpStatus.INTERNAL_SERVER_ERROR.value(),
                             HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-<<<<<<< HEAD
-                            "최근 업적 3개 조회 실패 - " + e.getMessage()));
-=======
                             "언팔로우 실패 - " + e.getMessage()));
         }
     }
@@ -338,7 +297,52 @@ public class MemberController implements MemberApi {
                             HttpStatus.INTERNAL_SERVER_ERROR.value(),
                             HttpStatus.INTERNAL_SERVER_ERROR.toString(),
                             "특정 사용자의 팔로워 목록 조회 실패 - " + e.getMessage()));
->>>>>>> 6bbd11ebac007ac9446af6469faf129db1413113
+        }
+    }
+
+
+    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
+    @GetMapping("/achievement")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        String email = memberDetails.getUsername();
+
+        try {
+            List<MemberAchievementResponseDTO> achievements = memberService.getAllAchievements(email);
+
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "모든 챌린지 업적 조회 성공", achievements));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "업적 조회 실패 - " + e.getMessage()));
+        }
+    }
+
+
+    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
+    @GetMapping("/achievement/top3")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        String email = memberDetails.getUsername();
+
+        try {
+            List<MemberAchievementResponseDTO> top3Achievements = memberService.getTop3Achievements(email);
+
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "최근 업적 3개 조회 성공", top3Achievements));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "최근 업적 3개 조회 실패 - " + e.getMessage()));
         }
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package BE_Elixir.Elixir.domain.member.controller;
 
 import BE_Elixir.Elixir.domain.member.controller.api.MemberApi;
 import BE_Elixir.Elixir.domain.member.dto.request.SignUpRequestDTO;
+import BE_Elixir.Elixir.domain.member.dto.response.MemberAchievementResponseDTO;
 import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
@@ -163,4 +164,25 @@ public class MemberController implements MemberApi {
         }
     }
 
+    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
+    @GetMapping("/achievement")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        String email = memberDetails.getUsername();
+
+        try {
+            List<MemberAchievementResponseDTO> achievements = memberService.getAllAchievements(email);
+
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "모든 챌린지 업적 조회 성공", achievements));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "업적 조회 실패 - " + e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -5,7 +5,6 @@ import BE_Elixir.Elixir.domain.member.dto.response.MemberAchievementResponseDTO;
 import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
 import BE_Elixir.Elixir.domain.member.dto.response.MemberSummaryDTO;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
-import BE_Elixir.Elixir.domain.recipe.dto.RecipeHomeResponseDTO;
 import BE_Elixir.Elixir.domain.recipe.dto.RecipeImageResponseDTO;
 import BE_Elixir.Elixir.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -182,5 +181,254 @@ public interface MemberApi {
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
-    
+    // 팔로우 하기
+    @Operation(summary = "팔로우 하기",
+            description = "현재 사용자가 다른 사용자를 팔로우합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로우 하기 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "팔로우 하기 성공",
+                                      "data": null
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "팔로우 하기 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "팔로우 하기 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<?>> follow(
+            @PathVariable("targetMemberId") Long followingId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // 언팔로우 하기
+    @Operation(summary = "언팔로우 하기",
+            description = "현재 사용자가 다른 사용자를 언팔로우합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "언팔로우 하기 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "언팔로우 하기 성공",
+                                      "data": null
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "언팔로우 하기 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "언팔로우 하기 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<?>> unfollow(
+            @PathVariable("targetMemberId") Long followingId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // (현재 사용자의) 팔로잉 목록 조회하기 (사용자가 팔로우하는 목록)
+    @Operation(summary = "현재 사용자의 팔로잉 목록 조회하기",
+            description = "현재 사용자가 팔로우하는 회원 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "현재 사용자의 팔로잉 목록 조회하기 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "현재 사용자의 팔로잉 목록 조회하기 성공",
+                                      "data": [
+                                          {
+                                            "id": 1,
+                                            "nickname": "example",
+                                            "profileUrl": "https://s3elixir.s3...",
+                                            "title": "봄동마스터"
+                                          }, ...
+                                      ]
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "현재 사용자의 팔로잉 목록 조회하기 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "현재 사용자의 팔로잉 목록 조회하기 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberSummaryDTO>>> getFollowing(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // (현재 사용자의) 팔로워 목록 조회하기 (사용자를 팔로잉하는 목록)
+    @Operation(summary = "현재 사용자의 팔로워 목록 조회하기",
+            description = "현재 사용자를 팔로우하는 회원 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "현재 사용자의 팔로워 목록 조회하기 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "현재 사용자의 팔로워 목록 조회하기 성공",
+                                      "data": [
+                                          {
+                                            "id": 1,
+                                            "nickname": "example",
+                                            "profileUrl": "https://s3elixir.s3...",
+                                            "title": "봄동마스터"
+                                          }, ...
+                                      ]
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "현재 사용자의 팔로워 목록 조회하기 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "현재 사용자의 팔로워 목록 조회하기 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberSummaryDTO>>> getFollower(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // (특정 사용자의) 팔로잉 목록 조회하기 (사용자가 팔로우하는 목록)
+    @Operation(summary = "특정 사용자의 팔로잉 목록 조회하기",
+            description = "특정 사용자가 팔로우하는 회원 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "특정 사용자의 팔로잉 목록 조회하기 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "특정 사용자의 팔로잉 목록 조회하기 성공",
+                                      "data": [
+                                          {
+                                            "id": 1,
+                                            "nickname": "example",
+                                            "profileUrl": "https://s3elixir.s3...",
+                                            "title": "봄동마스터"
+                                          }, ...
+                                      ]
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "특정 사용자의 팔로잉 목록 조회하기 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "특정 사용자의 팔로잉 목록 조회하기 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberSummaryDTO>>> getFollowingByMemberId(
+            @PathVariable("targetMemberId") Long targetMemberId
+    );
+
+    // (특정 사용자의) 팔로우 목록 조회하기 (사용자를 팔로잉하는 목록)
+    @Operation(summary = "특정 사용자의 팔로워 목록 조회하기",
+            description = "특정 사용자를 팔로우하는 회원 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "특정 사용자의 팔로워 목록 조회하기 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "특정 사용자의 팔로워 목록 조회하기 성공",
+                                      "data": [
+                                          {
+                                            "id": 1,
+                                            "nickname": "example",
+                                            "profileUrl": "https://s3elixir.s3...",
+                                            "title": "봄동마스터"
+                                          }, ...
+                                      ]
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "특정 사용자의 팔로워 목록 조회하기 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 401,
+                                      "code": "401 INTERNAL_SERVER_ERROR",
+                                      "message": "특정 사용자의 팔로워 목록 조회하기 중 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberSummaryDTO>>> getFollowerByMemberId(
+            @PathVariable("targetMemberId") Long targetMemberId
+    );
+
+
+    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
+    @Operation(summary = "로그인한 사용자의 모든 챌린지 업적 정보 조회하기", description = "로그인한 사용자의 모든 챌린지 업적 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 모든 챌린지 업적 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인한 사용자의 모든 챌린지 업적 정보 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+
+    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
+    @Operation(summary = "로그인한 사용자의 달성한 업적 최신 3개 조회하기", description = "로그인한 사용자의 달성한 업적 최신 3개를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 달성한 업적 최신 3개 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인한 사용자의 달성한 업적 최신 3개 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -1,6 +1,7 @@
 package BE_Elixir.Elixir.domain.member.controller.api;
 
 import BE_Elixir.Elixir.domain.member.dto.request.SignUpRequestDTO;
+import BE_Elixir.Elixir.domain.member.dto.response.MemberAchievementResponseDTO;
 import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.domain.recipe.dto.RecipeHomeResponseDTO;
@@ -181,4 +182,24 @@ public interface MemberApi {
     ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getMyScrapRecipes(
             @AuthenticationPrincipal MemberDetails memberDetails
     );
+
+    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
+    @Operation(summary = "로그인한 사용자의 모든 챌린지 업적 정보 조회하기", description = "로그인한 사용자의 모든 챌린지 업적 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 모든 챌린지 업적 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인한 사용자의 모든 챌린지 업적 정보 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -202,4 +202,23 @@ public interface MemberApi {
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
+
+    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
+    @Operation(summary = "로그인한 사용자의 달성한 업적 최신 3개 조회하기", description = "로그인한 사용자의 달성한 업적 최신 3개를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 달성한 업적 최신 3개 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인한 사용자의 달성한 업적 최신 3개 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberAchievementResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberAchievementResponseDTO.java
@@ -1,0 +1,15 @@
+package BE_Elixir.Elixir.domain.member.dto.response;
+
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberAchievementResponseDTO {
+    private int year;          // 챌린지 연도
+    private int month;         // 챌린지 월
+    private String achievementName; // 업적 명
+    private String achievementImageUrl; // 업적 이미지
+    private boolean challengeCompleted; // 챌린지 최종 달성 여부
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
@@ -1,6 +1,11 @@
 package BE_Elixir.Elixir.domain.member.service;
 
+import BE_Elixir.Elixir.domain.challenge.entity.Challenge;
+import BE_Elixir.Elixir.domain.challenge.entity.ChallengeAchievement;
+import BE_Elixir.Elixir.domain.challenge.repository.ChallengeAchievementRepository;
+import BE_Elixir.Elixir.domain.challenge.repository.ChallengeRepository;
 import BE_Elixir.Elixir.domain.member.dto.request.SignUpRequestDTO;
+import BE_Elixir.Elixir.domain.member.dto.response.MemberAchievementResponseDTO;
 import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.repository.MemberRepository;
@@ -24,6 +29,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,6 +41,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final RecipeRepository recipeRepository;
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeAchievementRepository challengeAchievementRepository;
     private final RecipeEventRepository recipeEventRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
@@ -240,5 +249,42 @@ public class MemberService {
                 .toList();
     }
 
+    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
+    public List<MemberAchievementResponseDTO> getAllAchievements(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
 
+        // 전체 챌린지 조회 (연도/월 기준)
+        List<Challenge> allChallenges = challengeRepository.findAllOrderedByYearAndMonth();
+
+        // 사용자의 챌린지 달성 정보 조회
+        List<ChallengeAchievement> achievements = challengeAchievementRepository.findByMemberId(member.getId());
+
+        Map<Long, ChallengeAchievement> achievementMap = achievements.stream()
+                .collect(Collectors.toMap(
+                        ChallengeAchievement::getChallengeId,
+                        a -> a
+                ));
+        return allChallenges.stream()
+                .map(challenge -> {
+                    ChallengeAchievement achievement = achievementMap.get(challenge.getId());
+
+                    // 달성여부
+                    boolean completed = (achievement != null) && achievement.isStep4Goal1Achieved() && achievement.isStep4Goal2Achieved();
+
+                    // 달성할 경우 컬러이미지, 달성하지 않았을 경우 흑백이미지
+                    String imageUrl = completed ?
+                            challenge.getAchievementImageUrl() :
+                            challenge.getGrayAchievementImageUrl();
+
+                    return new MemberAchievementResponseDTO(
+                            challenge.getYear(),
+                            challenge.getMonth(),
+                            challenge.getAchievementName(),
+                            imageUrl,
+                            completed
+                    );
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
@@ -287,4 +287,48 @@ public class MemberService {
                 })
                 .collect(Collectors.toList());
     }
+
+    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
+    public List<MemberAchievementResponseDTO> getTop3Achievements(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<ChallengeAchievement> achievements = challengeAchievementRepository.findByMemberId(member.getId());
+
+        // 챌린지 ID만 가져오기
+        Set<Long> challengeIds = achievements.stream()
+                .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
+                .map(ChallengeAchievement::getChallengeId)
+                .collect(Collectors.toSet());
+
+        // challengeId에 해당하는 챌린지를 한 번에 조회
+        List<Challenge> challenges = challengeRepository.findAllById(challengeIds);
+
+        // challengeId → Challenge 매핑
+        Map<Long, Challenge> challengeMap = challenges.stream()
+                .collect(Collectors.toMap(Challenge::getId, c -> c));
+
+        // 업적 필터 + 정렬 + DTO 변환
+        List<MemberAchievementResponseDTO> top3Achievements = achievements.stream()
+                .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
+                .sorted((a1, a2) -> {
+                    Challenge c1 = challengeMap.get(a1.getChallengeId());
+                    Challenge c2 = challengeMap.get(a2.getChallengeId());
+                    int compareYear = Integer.compare(c2.getYear(), c1.getYear());
+                    return (compareYear != 0) ? compareYear : Integer.compare(c2.getMonth(), c1.getMonth());
+                })
+                .limit(3)
+                .map(a -> {
+                    Challenge challenge = challengeMap.get(a.getChallengeId());
+                    return new MemberAchievementResponseDTO(
+                            challenge.getYear(),
+                            challenge.getMonth(),
+                            challenge.getAchievementName(),
+                            challenge.getAchievementImageUrl(), // 컬러 이미지
+                            true
+                    );
+                })
+                .collect(Collectors.toList());
+        return top3Achievements;
+    }
 }


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/38

## 🪐 작업 내용 - 기능 개발
- 로그인한 사용자의 모든 챌린지 업적 정보 조회 API 
- 로그인한 사용자가 달성한 최신 업적 3개 조회 API

## ✅ PR 상세 내용
- MemberAchievementResponseDTO로 두 API 응답 결과 반환
- 로그인한 사용자가 업적을 달성한 경우 컬러이미지로 반환, 달성하지 않은 경우 흑백이미지로 반환됨

## 📚 Reference
- X