### PR TITLE
fix: DEFAULT_URL을 배포된 주소로 변경 in SwaggerConfig

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/global/config/SwaggerConfig.java
+++ b/src/main/java/BE_Elixir/Elixir/global/config/SwaggerConfig.java
@@ -20,7 +20,7 @@ import java.util.List;
 )
 public class SwaggerConfig {
 
-    String DEFAULT_URL = "http://localhost:8080";
+    String DEFAULT_URL = "https://port-0-elixir-backend-g0424l70py8py.gksl2.cloudtype.app/";
 
     @Bean
     public OpenAPI openAPI() {


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/45

## 🪐 작업 내용
- SwaggerConfig의 DEFAULT_URL을 배포된 CloudType의 주소로 변경

## ✅ PR 상세 내용
- SwaggerConfig의 DEFAULT_URL을 배포된 CloudType의 주소로 변경

## 📚 Reference
- X