### PR TITLE
docs: swagger 문서화 api 자체 설명 추가, feat: 응답 시, 마크다운 볼드체 표현 제거 기능 추가

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/chatbot/controller/api/ChatbotApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/chatbot/controller/api/ChatbotApi.java
@@ -11,12 +11,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 
+@Tag(name = "Chatbot API", description = "챗봇 관련 API")
 public interface ChatbotApi {
 
     @Operation(summary = "챗봇에 메세지 전송 및 응답 메시지 받아오기",

--- a/src/main/java/BE_Elixir/Elixir/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/chatbot/service/ChatbotService.java
@@ -82,11 +82,14 @@ public class ChatbotService {
 
             redisChatbotService.printChatSessionValue(chatSessionId);
 
-            // 결과 DTO로 return
+            // 클리닝
+            String cleanedContent = response.get("content").replace("**", "");
+
             return ChatbotResponseDTO.builder()
                     .chatSessionId(chatSessionId)
-                    .message(response.get("content"))
+                    .message(cleanedContent)
                     .build();
+
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.error("잘못된 입력 또는 상태 오류: {}", e.getMessage());
             throw e;


### PR DESCRIPTION
## 📌 Issue Number
- closed #37 

## 🪐 작업 내용
- swagger 문서화 시, api 도메인 설명이 누락되어 추가
- 응답 시, 마크다운 볼드체 표현이 포함되는 경우가 있어 제거 기능 추가

## ✅ PR 상세 내용
- swagger 문서화 시, api 도메인 설명이 누락되어 추가
- 응답 시, 마크다운 볼드체 표현이 포함되는 경우가 있어 제거 기능 추가
    - ai에게 포함하지 않도록 설정했지만, 절대적인 설정이 아니기 때문

## 📚 Reference
- X