### PR TITLE
refactor: Challenge 엔티티의 description, purpose 필드의 타입을 TEXT로 변경

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/entity/Challenge.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/entity/Challenge.java
@@ -18,8 +18,16 @@ public class Challenge {
     private Long id;
 
     private String name; // 챌린지 명
+
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String description; // 챌린지 설명
+
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String purpose; // 챌린지 목적
+
+
     // private LocalDateTime startDate; // 시작 일시
     // private LocalDateTime endDate; // 끝나는 일시
     private int month; // 월


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/22

## 🪐 작업 내용
- Challenge 엔티티의 description, purpose 필드의 타입을 TEXT로 변경하여 긴 문자열 지원

## ✅ PR 상세 내용
- Challenge 엔티티의 description, purpose 필드의 타입을 TEXT로 변경하여 긴 문자열 지원

## 📚 Reference
- X