### PR TITLE
fix: 식단 월별 점수 조회 기능 문제 해결

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/dietLog/repository/DietLogRepository.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/dietLog/repository/DietLogRepository.java
@@ -18,11 +18,11 @@ public interface DietLogRepository extends JpaRepository<DietLog, Long> {
 
 
     // 특정 사용자의 월별 식단 점수 조회
-    @Query("SELECT d FROM DietLog d WHERE d.member.id = :memberId AND MONTH(d.time) = :month AND YEAR(d.time) = :year")
-    List<DietLog> findByMemberIdAndYearAndMonth(
+    @Query("SELECT d FROM DietLog d WHERE d.member.id = :memberId AND d.time BETWEEN :start AND :end")
+    List<DietLog> findByMemberIdAndMonthBetween(
             @Param("memberId") Long memberId,
-            @Param("month") int month,
-            @Param("year") int year
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
     );
 
     // 챌린지 목표 조건 확인

--- a/src/main/java/BE_Elixir/Elixir/domain/dietLog/service/DietLogService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/dietLog/service/DietLogService.java
@@ -185,8 +185,10 @@ public class DietLogService {
 
     // 월별 식단 점수 조회
     public List<MonthlyDietScoreDTO> getMonthlyDietScores(Long memberId, int year, int month) {
-        // 해당 월에 대한 모든 식단 조회
-        List<DietLog> dietLogs = dietLogRepository.findByMemberIdAndYearAndMonth(memberId, year, month);
+        LocalDateTime start = LocalDate.of(year, month, 1).atStartOfDay();
+        LocalDateTime end = start.plusMonths(1);
+
+        List<DietLog> dietLogs = dietLogRepository.findByMemberIdAndMonthBetween(memberId, start, end);
 
         return dietLogs.stream()
                 .map(dietLog -> MonthlyDietScoreDTO.builder()
@@ -197,5 +199,4 @@ public class DietLogService {
                 .collect(Collectors.toList());
 
     }
-
 }


### PR DESCRIPTION
## 📌 Issue Number
- closed #70 

## 🪐 작업 내용
- 식단 월별 점수 조회 기능 문제 해결

## ✅ PR 상세 내용
- 식단 월별 점수 조회 기능 문제 해결
    - 잘못 동작할 우려가 있던 YEAR(), MONTH() 메소드를 활용했던 기존의 JPQL 쿼리를 날짜의 범위로 조회하는 방식으로 수정함 

## 📚 Reference
- X