### PR TITLE
feat: 회원-레시피 관련 기능 개발(다른 사용자의 레시피 상위 9개 조회)

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -488,4 +488,23 @@ public class MemberController implements MemberApi {
                             "설문조사 수정 실패 - " + e.getMessage()));
         }
     }
+
+    // 다른 사용자가 업로드한 모든 레시피 조회하기
+    @GetMapping("/{memberId}/recipes")
+    public ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getUserRecipes(
+            @PathVariable("memberId") Long memberId
+    ) {
+        try {
+            List<RecipeImageResponseDTO> recipes = memberService.getUserRecipes(memberId);
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(), "다른 사용자 레시피 조회 성공", recipes));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "다른 사용자 레시피 조회 실패 - " + e.getMessage()));
+        }
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -636,4 +636,23 @@ public interface MemberApi {
             @RequestBody SurveyRequestDTO dto,
             @AuthenticationPrincipal MemberDetails memberDetails
     );
+
+    // 다른 사용자가 업로드한 모든 레시피 조회하기
+    @Operation(summary = "다른 사용자가 업로드한 모든 레시피 조회하기", description = "다른 사용자가 업로드한 모든 레시피 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 사용자가 업로드한 모든 레시피 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "다른 사용자가 업로드한 모든 레시피 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getUserRecipes(
+            @PathVariable("memberId") Long memberId
+    );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
@@ -526,4 +526,17 @@ public class MemberService {
         member.setReason_혈당조절(false);
         member.setReason_염증감소(false);
     }
+
+    // 다른 사용자가 업로드한 모든 레시피 조회하기
+    public List<RecipeImageResponseDTO> getUserRecipes(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Recipe> recipes = recipeRepository.findAllByMember(member);
+
+        return recipes.stream()
+                .map(recipe -> new RecipeImageResponseDTO(recipe.getId(), recipe.getImageUrl()))
+                .limit(9)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/23

## 🪐 작업 내용
- 특정 사용자의 ID를 기반으로 해당 사용자가 업로드한 레시피 목록을 조회하는 API 추가

## ✅ PR 상세 내용
- GET /api/member/{memberId}/recipes 엔드포인트 추가

## 📚 Reference
- X