### PR TITLE
feat: 회원-챌린지 관련 기능 개발(다른 사용자의 모든 챌린지 업적 조회/달성한 최신 업적 3개 조회)

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -525,4 +525,23 @@ public class MemberController implements MemberApi {
                             "다른 사용자의 업적 조회 실패 - " + e.getMessage()));
         }
     }
+
+    // 다른 사용자의 최근 3개 업적 조회하기
+    @GetMapping("/{memberId}/achievements/top3")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3AchievementsByMemberId(
+            @PathVariable Long memberId
+    ) {
+        try {
+            List<MemberAchievementResponseDTO> achievements = memberService.getTop3AchievementsByMemberId(memberId);
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "다른 사용자의 최근 업적 3개 조회 성공", achievements));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "다른 사용자의 최근 업적 3개 조회 실패 - " + e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -507,4 +507,22 @@ public class MemberController implements MemberApi {
         }
     }
 
+    // 다른 사용자의 모든 챌린지 업적 정보 조회하기
+    @GetMapping("/{memberId}/achievements")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievementsByMemberId(
+            @PathVariable Long memberId
+    ) {
+        try {
+            List<MemberAchievementResponseDTO> achievements = memberService.getAllAchievementsByMemberId(memberId);
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "다른 사용자의 모든 업적 조회 성공", achievements));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "다른 사용자의 업적 조회 실패 - " + e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -675,4 +675,24 @@ public interface MemberApi {
     ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievementsByMemberId(
             @PathVariable Long memberId
     );
+
+
+    // 다른 사용자의 최근 3개 업적 조회하기
+    @Operation(summary = "다른 사용자의 최근 3개 업적 조회하기", description = "다른 사용자의 최근 3개 업적 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 사용자의 최근 3개 업적 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "다른 사용자의 최근 3개 업적 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3AchievementsByMemberId(
+            @PathVariable Long memberId
+    );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -655,4 +655,24 @@ public interface MemberApi {
     ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getUserRecipes(
             @PathVariable("memberId") Long memberId
     );
+
+
+    // 다른 사용자의 모든 챌린지 업적 정보 조회하기
+    @Operation(summary = "다른 사용자의 모든 챌린지 업적 정보 조회하기", description = "다른 사용자의 모든 챌린지 업적 정보 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 사용자의 모든 챌린지 업적 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "다른 사용자의 모든 챌린지 업적 정보 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievementsByMemberId(
+            @PathVariable Long memberId
+    );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
@@ -572,4 +572,45 @@ public class MemberService {
                     );
                 }).collect(Collectors.toList());
     }
+
+    // 다른 사용자의 최신 업적 3개 조회
+    public List<MemberAchievementResponseDTO> getTop3AchievementsByMemberId(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<ChallengeAchievement> achievements = challengeAchievementRepository.findByMemberId(member.getId());
+
+        Set<Long> challengeIds = achievements.stream()
+                .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
+                .map(ChallengeAchievement::getChallengeId)
+                .collect(Collectors.toSet());
+
+        List<Challenge> challenges = challengeRepository.findAllById(challengeIds);
+
+        Map<Long, Challenge> challengeMap = challenges.stream()
+                .collect(Collectors.toMap(Challenge::getId, c -> c));
+
+        return achievements.stream()
+                .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
+                .sorted((a1, a2) -> {
+                    Challenge c1 = challengeMap.get(a1.getChallengeId());
+                    Challenge c2 = challengeMap.get(a2.getChallengeId());
+                    int compareYear = Integer.compare(c2.getYear(), c1.getYear());
+                    return (compareYear != 0)
+                            ? compareYear
+                            : Integer.compare(c2.getMonth(), c1.getMonth());
+                })
+                .limit(3)
+                .map(a -> {
+                    Challenge challenge = challengeMap.get(a.getChallengeId());
+                    return new MemberAchievementResponseDTO(
+                            challenge.getYear(),
+                            challenge.getMonth(),
+                            challenge.getAchievementName(),
+                            challenge.getAchievementImageUrl(),
+                            true
+                    );
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
@@ -539,4 +539,37 @@ public class MemberService {
                 .limit(9)
                 .collect(Collectors.toList());
     }
+
+    // 다른 사용자의 모든 챌린지 업적 정보 조회하기
+    public List<MemberAchievementResponseDTO> getAllAchievementsByMemberId(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Challenge> allChallenges = challengeRepository.findAllOrderedByYearAndMonth();
+        List<ChallengeAchievement> achievements = challengeAchievementRepository.findByMemberId(member.getId());
+
+        Map<Long, ChallengeAchievement> achievementMap = achievements.stream()
+                .collect(Collectors.toMap(ChallengeAchievement::getChallengeId, a -> a));
+
+        return allChallenges.stream()
+                .map(challenge -> {
+                    ChallengeAchievement achievement = achievementMap.get(challenge.getId());
+
+                    boolean completed = (achievement != null)
+                            && achievement.isStep4Goal1Achieved()
+                            && achievement.isStep4Goal2Achieved();
+
+                    String imageUrl = completed
+                            ? challenge.getAchievementImageUrl()
+                            : challenge.getGrayAchievementImageUrl();
+
+                    return new MemberAchievementResponseDTO(
+                            challenge.getYear(),
+                            challenge.getMonth(),
+                            challenge.getAchievementName(),
+                            imageUrl,
+                            completed
+                    );
+                }).collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/38

## 🪐 작업 내용 - 기능 개발
- 특정 사용자의 전체 업적 및 최신 업적 3개를 조회하는 API 구현

## ✅ PR 상세 내용
- GET /api/member/{memberId}/achievements: 특정 사용자의 모든 챌린지 업적 정보 조회 
- GET /api/member/{memberId}/achievements/top3: 특정 사용자의 최근 업적 3개 조회

## 📚 Reference 
- X