### PR TITLE
fix: 파일 업로드 시 파일 크기 오류로 인한 크기 제한 설정

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -47,6 +47,8 @@ aws.accessKeyId=${AWS_ACCESSKEY}
 aws.secretKey=${AWS_SECRETKEY}
 aws.region=ap-northeast-2
 aws.bucketName=s3elixir
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
 
 # permit all patterns
 security.whitelist[0]=/test


### PR DESCRIPTION
## 📌 Issue Number
- #81

## 🪐 작업 내용
- 파일 업로드 시 파일 크기 오류로 인한 크기 제한 설정

## ✅ PR 상세 내용
- Multipart 파일의 최대 업로드 크기를 10MB로 설정

## 📚 Reference
- X