### PR TITLE
feat: 로그인한 사용자의 이전 챌린지 진행 상황 조회 API 구현

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
@@ -117,6 +117,22 @@ public class ChallengeController implements ChallengeApi {
         }
     }
 
-
-
+    // 로그인한 사용자의 이전 챌린지 진행 상황 조회
+    @GetMapping("/{challengeId}/progress")
+    public ResponseEntity<CommonResponse<ChallengeProgressResponseDTO>> getProgress(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable Long challengeId
+    ) {
+        try{
+            Member member = memberDetails.getMember();
+            ChallengeProgressResponseDTO dto = challengeAchievementService.getBeforeProgress(member.getId(), challengeId);
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    memberDetails.getUsername() + " 사용자의 이전 챌린지 진행 상황 조회 성공", dto));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            memberDetails.getUsername() + " 사용자의 이전 챌린지 진행 상황 조회 실패 - " + e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/api/ChallengeApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/api/ChallengeApi.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -129,5 +130,28 @@ public interface ChallengeApi {
     })
     ResponseEntity<CommonResponse<ChallengeCompletedResponseDTO>> getChallengeCompletion(
             @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+
+    // 로그인한 사용자의 이전 챌린지 진행 상황 조회
+    @Operation(summary = "사용자의 이전 챌린지 진행 상황 조회", description = "사용자의 이전 챌린지 진행 상황 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자의 이전 챌린지 진행 상황 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "사용자의 이전 챌린지 진행 상황 조회 성공",
+                                      "data": true
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "500", description = "사용자의 이전 챌린지 진행 상황 조회 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    ResponseEntity<CommonResponse<ChallengeProgressResponseDTO>> getProgress(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable Long challengeId
     );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeProgressResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/dto/response/ChallengeProgressResponseDTO.java
@@ -86,4 +86,39 @@ public class ChallengeProgressResponseDTO {
                 .challengeCompleted(completed)
                 .build();
     }
+
+    public static ChallengeProgressResponseDTO empty(Challenge challenge) {
+        return ChallengeProgressResponseDTO.builder()
+                .challengeId(challenge.getId())
+                .name(challenge.getName())
+                .year(challenge.getYear())
+                .month(challenge.getMonth())
+
+                // 1단계
+                .step1Goal1Achieved(false)
+                .step1Goal2Achieved(false)
+
+                // 2단계
+                .step2Goal1Active(false)
+                .step2Goal2Active(false)
+                .step2Goal1Achieved(false)
+                .step2Goal2Achieved(false)
+
+                // 3단계
+                .step3Goal1Active(false)
+                .step3Goal2Active(false)
+                .step3Goal1Achieved(false)
+                .step3Goal2Achieved(false)
+
+                // 4단계
+                .step4Goal1Active(false)
+                .step4Goal2Active(false)
+                .step4Goal1Achieved(false)
+                .step4Goal2Achieved(false)
+
+                // 최종 완료 여부
+                .challengeCompleted(false)
+                .build();
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
@@ -104,4 +104,20 @@ public class ChallengeAchievementService {
             );
         }
     }
+
+    // 로그인한 사용자의 이전 챌린지 진행 상황 조회
+    public ChallengeProgressResponseDTO getBeforeProgress(Long memberId, Long challengeId) {
+
+        Challenge challenge = challengeRepository
+                .findById(challengeId)
+                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+        Optional<ChallengeAchievement> optionalAchievement =
+                challengeAchievementRepository.findByChallengeIdAndMemberId(challengeId, memberId);
+
+        return optionalAchievement
+                .map(achievement -> ChallengeProgressResponseDTO.from(challenge, achievement))
+                .orElseGet(() -> ChallengeProgressResponseDTO.empty(challenge));
+    }
+
 }


### PR DESCRIPTION
## 📌 Issue Number
- #22

## 🪐 작업 내용
- 로그인한 사용자의 이전 챌린지 진행 상황 조회 API 구현

## ✅ PR 상세 내용
- 로그인한 사용자의 이전 챌린지 진행 상황 조회 API 구현

## 📚 Reference
- X