### PR TITLE
feat: 로그인한 사용자가 작성한 레시피 최대 10개 조회 API 구현

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
@@ -7,6 +7,7 @@ import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeDetailResponseDTO;
 import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeHomeResponseDTO;
 import BE_Elixir.Elixir.domain.recipe.dto.request.RecipeRequestDTO;
 import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeResponseDTO;
+import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeSummaryResponse;
 import BE_Elixir.Elixir.domain.recipe.service.RecipeService;
 import BE_Elixir.Elixir.global.enums.CategorySlowAging;
 import BE_Elixir.Elixir.global.enums.CategoryType;
@@ -203,4 +204,25 @@ public class RecipeController implements RecipeApi {
         }
     }
 
+    // 로그인한 사용자가 작성한 레시피를 최대 10개까지 조회
+    @GetMapping("/my")
+    public ResponseEntity<CommonResponse<List<RecipeSummaryResponse>>> getMyRecipes(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        try {
+            Member member = memberDetails.getMember();
+            List<RecipeSummaryResponse> recipes = recipeService.getMyRecipes(member, size);
+            return ResponseEntity.ok(CommonResponse.success(
+                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                    "작성한 레시피 조회 성공", recipes
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CommonResponse.error(
+                            HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+                            "작성한 레시피 조회 실패 - " + e.getMessage()
+                    ));
+        }
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
@@ -3,6 +3,7 @@ package BE_Elixir.Elixir.domain.recipe.controller.api;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeDetailResponseDTO;
 import BE_Elixir.Elixir.domain.recipe.dto.request.RecipeRequestDTO;
+import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeSummaryResponse;
 import BE_Elixir.Elixir.global.enums.CategorySlowAging;
 import BE_Elixir.Elixir.global.enums.CategoryType;
 import BE_Elixir.Elixir.global.response.CommonResponse;
@@ -187,5 +188,25 @@ public interface RecipeApi {
     ResponseEntity<CommonResponse<?>> deleteRecipe(
             @PathVariable Long recipeId,
             @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // 로그인한 사용자가 작성한 레시피를 최대 10개까지 조회
+    @Operation(summary = "작성한 레시피를 최대 10개까지 조회", description = "작성한 레시피를 최대 10개까지 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "작성한 레시피를 최대 10개까지 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "작성한 레시피를 최대 10개까지 조회 성공",
+                                      "data": true
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<RecipeSummaryResponse>>> getMyRecipes(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestParam(defaultValue = "10") int size
     );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeSummaryResponse.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeSummaryResponse.java
@@ -1,0 +1,28 @@
+package BE_Elixir.Elixir.domain.recipe.dto.response;
+
+import BE_Elixir.Elixir.domain.recipe.entity.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class RecipeSummaryResponse {
+    private Long recipeId;
+    private String imageUrl;
+    private String title;
+    private List<Long> ingredientTags;
+
+    public static RecipeSummaryResponse from(Recipe recipe) {
+        return new RecipeSummaryResponse(
+                recipe.getId(),
+                recipe.getImageUrl(),
+                recipe.getTitle(),
+                recipe.getIngredientTags().stream()
+                        .map(tag -> tag.getIngredient().getId())
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/repository/RecipeRepository.java
@@ -46,6 +46,11 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
             "WHERE r.member.id = :memberId " +
             "AND r.createdAt >= :openedAt")
     List<String> findIngredientsByMemberIdAndTimeAfter(@Param("memberId") Long memberId, @Param("openedAt") LocalDateTime openedAt);
+
+    // 사용자가 작성한 레시피 size만큼 가져오기
+    @Query(value = "SELECT * FROM recipe WHERE member_id = :memberId ORDER BY created_at DESC LIMIT :size", nativeQuery = true)
+    List<Recipe> findTopRecipesByUserId(@Param("memberId") Long userId, @Param("size") int size);
+
 }
 
 

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
@@ -6,10 +6,7 @@ import BE_Elixir.Elixir.domain.follow.repository.FollowRepository;
 import BE_Elixir.Elixir.domain.ingredient.entity.Ingredient;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.recipe.dto.request.RecipeRequestDTO;
-import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeCommentResponseDTO;
-import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeDetailResponseDTO;
-import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeHomeResponseDTO;
-import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeResponseDTO;
+import BE_Elixir.Elixir.domain.recipe.dto.response.*;
 import BE_Elixir.Elixir.domain.recipe.entity.Recipe;
 import BE_Elixir.Elixir.domain.recipe.entity.RecipeIngredient;
 import BE_Elixir.Elixir.domain.ingredient.repository.IngredientRepository;
@@ -288,5 +285,13 @@ public class RecipeService {
         recipe.clearIngredientTags();
 
         recipeRepository.delete(recipe);
+    }
+
+    // 로그인한 사용자가 작성한 레시피를 최대 10개까지 조회
+    public List<RecipeSummaryResponse> getMyRecipes(Member member, int size) {
+        List<Recipe> recipes = recipeRepository.findTopRecipesByUserId(member.getId(), size);
+        return recipes.stream()
+                .map(RecipeSummaryResponse::from)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📌 Issue Number
- #3

## 🪐 작업 내용
- 로그인한 사용자가 작성한 레시피 최대 10개 조회 API 구현

## ✅ PR 상세 내용
- 로그인한 사용자가 작성한 레시피 최대 10개 조회 API 구현

## 📚 Reference
- X