### PR TITLE
docs: Swagger 문서의 data 필드에 실제 응답 예시 추가

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/api/ChallengeApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/api/ChallengeApi.java
@@ -32,10 +32,36 @@ public interface ChallengeApi {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "status": 201,
-                                      "code": "201 OK",
-                                      "message": "챌린지 등록 성공",
-                                      "data": true
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "챌린지 등록 완료",
+                                      "data": {
+                                        "id": 6,
+                                        "name": "챌린지 명",
+                                        "description": "챌린지 설명",
+                                        "purpose": "챌린지 목적",
+                                        "month": 5,
+                                        "year": 2025,
+                                        "step1Goal1Type": "DIET_SEASONAL_ONCE",
+                                        "step1Goal2Type": "DIET_LUNCH",
+                                        "step2Goal1Type": "DIET_SEASONAL_ONCE",
+                                        "step2Goal2Type": "DIET_BREAKFAST",
+                                        "step3Goal1Type": "DIET_SEASONAL_ONCE",
+                                        "step3Goal2Type": "DIET_THREE_MEALS",
+                                        "step4Goal1Type": "RECIPE_SEASONAL_ONCE",
+                                        "step4Goal2Type": "DIET_60_A_MONTH",
+                                        "step1Goal1Desc": "하루 한 끼 재철 식재료를 포함한 식사",
+                                        "step1Goal2Desc": "점심 챙겨 먹기",
+                                        "step2Goal1Desc": "하루 한 끼 재철 식재료를 포함한 식사",
+                                        "step2Goal2Desc": "아침 챙겨 먹기",
+                                        "step3Goal1Desc": "하루 한 끼 재철 식재료를 포함한 식사",
+                                        "step3Goal2Desc": "하루 3끼 식단 기록",
+                                        "step4Goal1Desc": "재철 식재료를 활용한 레시피 작성",
+                                        "step4Goal2Desc": "1달 동안 누적 60끼 식단 기록",
+                                        "achievementName": "업적 명",
+                                        "achievementImageUrl": "업적 달성 이미지",
+                                        "grayAchievementImageUrl": "업적 미달성 이미지"
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "500", description = "챌린지 등록 실패",
@@ -57,8 +83,44 @@ public interface ChallengeApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "연도 별 챌린지 조회 성공",
-                                      "data": true
+                                      "message": "2025년도 챌린지 목록 조회 성공",
+                                      "data": [
+                                        {
+                                          "id": 1,
+                                          "name": "2월 챌린지",
+                                          "month": 2,
+                                          "year": 2025,
+                                          "achievementName": "비타민 수호자"
+                                        },
+                                        {
+                                          "id": 2,
+                                          "name": "3월 챌린지",
+                                          "month": 3,
+                                          "year": 2025,
+                                          "achievementName": "비타민 수호자"
+                                        },
+                                        {
+                                          "id": 3,
+                                          "name": "4월 챌린지",
+                                          "month": 4,
+                                          "year": 2025,
+                                          "achievementName": "비타민 수호자"
+                                        },
+                                        {
+                                          "id": 4,
+                                          "name": "5월 봄맞이 챌린지",
+                                          "month": 5,
+                                          "year": 2025,
+                                          "achievementName": "비타민 수호자"
+                                        },
+                                        {
+                                          "id": 5,
+                                          "name": "6월 챌린지",
+                                          "month": 6,
+                                          "year": 2025,
+                                          "achievementName": "비타민 수호자"
+                                        }
+                                      ]
                                     }
                                     """))),
             @ApiResponse(responseCode = "500", description = "연도 별 챌린지 조회 실패",
@@ -79,8 +141,27 @@ public interface ChallengeApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "특정 챌린지 조회 성공",
-                                      "data": true
+                                      "message": "챌린지 상세 조회 성공",
+                                      "data": {
+                                        "ingredients": [
+                                          "냉이",
+                                          "달래",
+                                          "쑥"
+                                        ],
+                                        "name": "3월 챌린지",
+                                        "period": "3월 1일 ~ 3월 31일",
+                                        "description": "설명- 3월 챌린지입니다.(식재료: 쑥 id: 1142)",
+                                        "purpose": "목적- 3월 챌린지입니다.",
+                                        "step1Goal1Desc": "하루 한 끼 재철 식재료를 포함한 식사",
+                                        "step1Goal2Desc": "점심 챙겨 먹기",
+                                        "step2Goal1Desc": "하루 한 끼 재철 식재료를 포함한 식사",
+                                        "step2Goal2Desc": "아침 챙겨 먹기",
+                                        "step3Goal1Desc": "하루 한 끼 재철 식재료를 포함한 식사",
+                                        "step3Goal2Desc": "하루 3끼 식단 기록",
+                                        "step4Goal1Desc": "재철 식재료를 활용한 레시피 작성",
+                                        "step4Goal2Desc": "1달 동안 누적 60끼 식단 기록",
+                                        "achievementName": "비타민 수호자"
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "500", description = "특정 챌린지 조회 실패",
@@ -100,8 +181,28 @@ public interface ChallengeApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "사용자의 현재 진행 상황 조회 성공",
-                                      "data": true
+                                      "message": "A@example.com 사용자의 현재 진행 상황 조회 성공",
+                                      "data": {
+                                        "challengeId": 5,
+                                        "name": "6월 챌린지",
+                                        "year": 2025,
+                                        "month": 6,
+                                        "step1Goal1Achieved": false,
+                                        "step1Goal2Achieved": false,
+                                        "step2Goal1Active": false,
+                                        "step2Goal2Active": false,
+                                        "step2Goal1Achieved": false,
+                                        "step2Goal2Achieved": false,
+                                        "step3Goal1Active": false,
+                                        "step3Goal2Active": false,
+                                        "step3Goal1Achieved": false,
+                                        "step3Goal2Achieved": false,
+                                        "step4Goal1Active": false,
+                                        "step4Goal2Active": false,
+                                        "step4Goal1Achieved": false,
+                                        "step4Goal2Achieved": false,
+                                        "challengeCompleted": false
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "500", description = "사용자의 현재 진행 상황 조회 실패",
@@ -122,7 +223,12 @@ public interface ChallengeApi {
                                       "status": 200,
                                       "code": "200 OK",
                                       "message": "챌린지 최종 완료 여부 조회 성공",
-                                      "data": true
+                                      "data": {
+                                        "achievementName": "비타민 수호자",
+                                        "message": "아직 챌린지를 달성하지 못했습니다.",
+                                        "achievementImageUrl": null,
+                                        "challengeCompleted": false
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "500", description = "챌린지 최종 완료 여부 조회 실패",
@@ -143,8 +249,28 @@ public interface ChallengeApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "사용자의 이전 챌린지 진행 상황 조회 성공",
-                                      "data": true
+                                      "message": "A@example.com 사용자의 이전 챌린지 진행 상황 조회 성공",
+                                      "data": {
+                                        "challengeId": 2,
+                                        "name": "3월 챌린지",
+                                        "year": 2025,
+                                        "month": 3,
+                                        "step1Goal1Achieved": true,
+                                        "step1Goal2Achieved": true,
+                                        "step2Goal1Active": true,
+                                        "step2Goal2Active": true,
+                                        "step2Goal1Achieved": true,
+                                        "step2Goal2Achieved": true,
+                                        "step3Goal1Active": true,
+                                        "step3Goal2Active": true,
+                                        "step3Goal1Achieved": true,
+                                        "step3Goal2Achieved": true,
+                                        "step4Goal1Active": true,
+                                        "step4Goal2Active": true,
+                                        "step4Goal1Achieved": true,
+                                        "step4Goal2Achieved": true,
+                                        "challengeCompleted": true
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "500", description = "사용자의 이전 챌린지 진행 상황 조회 실패",

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -395,8 +395,13 @@ public interface MemberApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "내가 작성한 레시피 조회 성공",
-                                      "data": true
+                                      "message": "내 레시피 조회 성공",
+                                      "data": [
+                                        {
+                                          "recipeId": 49,
+                                          "imageUrl": "https://image.com"
+                                        }
+                                      ]
                                     }
                                     """)))
     })
@@ -415,7 +420,16 @@ public interface MemberApi {
                                       "status": 200,
                                       "code": "200 OK",
                                       "message": "내가 스크랩한 레시피 조회 성공",
-                                      "data": true
+                                      "data": [
+                                        {
+                                          "recipeId": 1,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png"
+                                        },
+                                        {
+                                          "recipeId": 2,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png"
+                                        }
+                                      ]
                                     }
                                     """)))
     })
@@ -642,11 +656,47 @@ public interface MemberApi {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "status": 200,
-                                      "code": "200 OK",
-                                      "message": "로그인한 사용자의 모든 챌린지 업적 정보 조회 성공",
-                                      "data": true
-                                    }
+                                       "status": 200,
+                                       "code": "200 OK",
+                                       "message": "모든 챌린지 업적 조회 성공",
+                                       "data": [
+                                         {
+                                           "year": 2025,
+                                           "month": 2,
+                                           "achievementName": "비타민 수호자",
+                                           "achievementImageUrl": "https://example.com/images/color_2.png",
+                                           "challengeCompleted": true
+                                         },
+                                         {
+                                           "year": 2025,
+                                           "month": 3,
+                                           "achievementName": "비타민 수호자",
+                                           "achievementImageUrl": "https://example.com/images/color_3.png",
+                                           "challengeCompleted": true
+                                         },
+                                         {
+                                           "year": 2025,
+                                           "month": 4,
+                                           "achievementName": "비타민 수호자",
+                                           "achievementImageUrl": "https://example.com/images/color_4.png",
+                                           "challengeCompleted": true
+                                         },
+                                         {
+                                           "year": 2025,
+                                           "month": 5,
+                                           "achievementName": "비타민 수호자",
+                                           "achievementImageUrl": "https://example.com/images/gray_5.png",
+                                           "challengeCompleted": false
+                                         },
+                                         {
+                                           "year": 2025,
+                                           "month": 6,
+                                           "achievementName": "비타민 수호자",
+                                           "achievementImageUrl": "https://example.com/images/gray_6.png",
+                                           "challengeCompleted": false
+                                         }
+                                       ]
+                                     }
                                     """)))
     })
     ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
@@ -664,8 +714,30 @@ public interface MemberApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "로그인한 사용자의 달성한 업적 최신 3개 조회 성공",
-                                      "data": true
+                                      "message": "최근 업적 3개 조회 성공",
+                                      "data": [
+                                        {
+                                          "year": 2025,
+                                          "month": 4,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/color_4.png",
+                                          "challengeCompleted": true
+                                        },
+                                        {
+                                          "year": 2025,
+                                          "month": 3,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/color_3.png",
+                                          "challengeCompleted": true
+                                        },
+                                        {
+                                          "year": 2025,
+                                          "month": 2,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/color_2.png",
+                                          "challengeCompleted": true
+                                        }
+                                      ]
                                     }
                                     """)))
     })
@@ -756,8 +828,24 @@ public interface MemberApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "다른 사용자가 업로드한 모든 레시피 조회 성공",
-                                      "data": true
+                                      "message": "다른 사용자 레시피 조회 성공",
+                                      "data": [
+                                        {
+                                          "recipeId": 1,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png"
+                                        },
+                                        {
+                                          "recipeId": 2,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png"
+                                        },
+                                        .
+                                        .
+                                        .
+                                        {
+                                          "recipeId": 9,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00089_1.png"
+                                        }
+                                      ]
                                     }
                                     """)))
     })
@@ -776,8 +864,26 @@ public interface MemberApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "다른 사용자의 모든 챌린지 업적 정보 조회 성공",
-                                      "data": true
+                                      "message": "다른 사용자의 모든 업적 조회 성공",
+                                      "data": [
+                                        {
+                                          "year": 2025,
+                                          "month": 2,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/gray_2.png",
+                                          "challengeCompleted": false
+                                        },
+                                        .
+                                        .
+                                        .
+                                        {
+                                          "year": 2025,
+                                          "month": 6,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/gray_6.png",
+                                          "challengeCompleted": false
+                                        }
+                                      ]
                                     }
                                     """)))
     })
@@ -796,8 +902,30 @@ public interface MemberApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "다른 사용자의 최근 3개 업적 조회 성공",
-                                      "data": true
+                                      "message": "다른 사용자의 최근 업적 3개 조회 성공",
+                                      "data": [
+                                        {
+                                          "year": 2025,
+                                          "month": 4,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/color_4.png",
+                                          "challengeCompleted": true
+                                        },
+                                        {
+                                          "year": 2025,
+                                          "month": 3,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/color_3.png",
+                                          "challengeCompleted": true
+                                        },
+                                        {
+                                          "year": 2025,
+                                          "month": 2,
+                                          "achievementName": "비타민 수호자",
+                                          "achievementImageUrl": "https://example.com/images/color_2.png",
+                                          "challengeCompleted": true
+                                        }
+                                      ]
                                     }
                                     """)))
     })

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
@@ -34,14 +34,52 @@ public interface RecipeApi {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "status": 201,
-                                      "code": "201 OK",
+                                      "status": 200,
+                                      "code": "201 CREATED",
                                       "message": "레시피 등록 성공",
-                                      "data": true
+                                      "data": {
+                                        "id": 49,
+                                        "email": "A@example.com",
+                                        "title": "닭가슴살 덮밥",
+                                        "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00281_1.png",
+                                        "description": "닭가슴살로 간단히 덮밥해먹기",
+                                        "categorySlowAging": "염증감소",
+                                        "categoryType": "한식",
+                                        "difficulty": "쉬움",
+                                        "timeHours": 0,
+                                        "timeMinutes": 45,
+                                        "ingredientTagIds": [
+                                          1
+                                        ],
+                                        "ingredients": {
+                                          "물": "2ml(1/3작은술)"
+                                        },
+                                        "seasoning": {
+                                          "설탕": "2g(1/3작은술)"
+                                        },
+                                        "stepDescriptions": [
+                                          "닭가슴살을 전자레인지에 데운다"
+                                        ],
+                                        "stepImageUrls": "http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_5.png",
+                                        "tips": "닭가슴살을 잘게 자를수록 더 맛있음",
+                                        "likes": 0,
+                                        "scraps": 0,
+                                        "createdAt": "2025-06-03T00:08:22.319638443",
+                                        "updatedAt": "2025-06-03T00:08:22.31966641",
+                                        "allergies": []
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "500", description = "레시피 등록 실패",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 500,
+                                      "code": "500 INTERNAL_SERVER_ERROR",
+                                      "message": "레시피 등록 실패 - 재료 없음: 0",
+                                      "data": null
+                                    }
+                                    """)))
     })
     ResponseEntity<CommonResponse<?>> createRecipe(
             @RequestPart("dto") RecipeRequestDTO dto,
@@ -60,8 +98,61 @@ public interface RecipeApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "레시피 상세 조회 성공",
-                                      "data": true
+                                      "message": "레시피 조회 성공",
+                                      "data": {
+                                        "authorFollowByCurrentUser": false,
+                                        "comments": [],
+                                        "likedByCurrentUser": false,
+                                        "scrappedByCurrentUser": false,
+                                        "id": 3,
+                                        "authorNickname": "mj",
+                                        "authorTitle": null,
+                                        "title": "방울토마토 소박이",
+                                        "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00031_1.png",
+                                        "description": "기타",
+                                        "categorySlowAging": "염증감소",
+                                        "categoryType": "한식",
+                                        "difficulty": "쉬움",
+                                        "timeHours": 0,
+                                        "timeMinutes": 45,
+                                        "ingredientTagIds": [
+                                          1106,
+                                          1198,
+                                          5,
+                                          1101
+                                        ],
+                                        "ingredients": {
+                                          "통깨": "약간",
+                                          "방울토마토": "150g(5개)",
+                                          "부추": "10g(5줄기)",
+                                          "물": "2ml(1/3작은술)"
+                                        },
+                                        "seasoning": {
+                                          "고춧가루": "4g(1작은술)",
+                                          "멸치액젓": "3g(2/3작은술)",
+                                          "다진 마늘": "2.5g(1/2쪽)",
+                                          "매실액": "2g(1/3작은술)",
+                                          "양파": "10g(3×1cm)",
+                                          "설탕": "2g(1/3작은술)"
+                                        },
+                                        "stepDescriptions": [
+                                          "물기를 빼고 2cm 정도의 크기로 썰은 부추와 양파를 양념장에 섞어 양념속을 만든다.",
+                                          "깨끗이 씻은 방울토마토는 꼭지를 떼고 윗부분에 칼로 십자모양으로 칼집을 낸다.",
+                                          "칼집을 낸 방울토마토에 양념속을 사이사이에 넣어 버무린다."
+                                        ],
+                                        "stepImageUrls": [
+                                          "http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_1.png",
+                                          "http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_4.png",
+                                          "http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_5.png"
+                                        ],
+                                        "tips": "소금에 절이는 오이 대신 방울토마토를 사용하여 나트륨 섭취를 줄였어요. 토마토에는 과일에 대체로 없는 글루탐산이 풍부하여 감칠맛을 내주며, 겉절이 양념과 잘 어우러져 상큼함과 감칠맛을 내주어요.",
+                                        "likes": 0,
+                                        "createdAt": "2025-05-21T10:19:09",
+                                        "updatedAt": "2025-05-21T10:19:09",
+                                        "allergies": [
+                                          "토마토"
+                                        ]
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "404", description = "레시피 없음",
@@ -82,8 +173,70 @@ public interface RecipeApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "레시피 목록(홈) 조회 성공",
-                                      "data": true
+                                      "message": "전체 레시피 조회 성공",
+                                      "data": {
+                                        "content": [
+                                          {
+                                            "likedByCurrentUser": false,
+                                            "scrappedByCurrentUser": false,
+                                            "id": 49,
+                                            "title": "string",
+                                            "imageUrl": null,
+                                            "categorySlowAging": "항산화강화",
+                                            "categoryType": "한식",
+                                            "difficulty": "쉬움",
+                                            "totalTimeMinutes": 0,
+                                            "ingredientTagIds": [
+                                              1
+                                            ],
+                                            "likes": 0
+                                          },
+                                          {
+                                            "likedByCurrentUser": false,
+                                            "scrappedByCurrentUser": false,
+                                            "id": 1,
+                                            "title": "새우 두부 계란찜",
+                                            "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png",
+                                            "categorySlowAging": "염증감소",
+                                            "categoryType": "한식",
+                                            "difficulty": "보통",
+                                            "totalTimeMinutes": 45,
+                                            "ingredientTagIds": [
+                                              280,
+                                              599
+                                            ],
+                                            "likes": 0
+                                          }
+                                          .
+                                          .
+                                          .
+                                        ],
+                                        "pageable": {
+                                          "pageNumber": 0,
+                                          "pageSize": 10,
+                                          "sort": {
+                                            "empty": false,
+                                            "sorted": true,
+                                            "unsorted": false
+                                          },
+                                          "offset": 0,
+                                          "paged": true,
+                                          "unpaged": false
+                                        },
+                                        "last": false,
+                                        "totalPages": 5,
+                                        "totalElements": 49,
+                                        "size": 10,
+                                        "number": 0,
+                                        "sort": {
+                                          "empty": false,
+                                          "sorted": true,
+                                          "unsorted": false
+                                        },
+                                        "numberOfElements": 10,
+                                        "first": true,
+                                        "empty": false
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "404", description = "레시피 없음",
@@ -105,11 +258,57 @@ public interface RecipeApi {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "status": 200,
-                                      "code": "200 OK",
-                                      "message": "레시피 검색 결과 조회 성공",
-                                      "data": true
-                                    }
+                                       "status": 200,
+                                       "code": "200 OK",
+                                       "message": "레시피 검색 성공",
+                                       "data": {
+                                         "content": [
+                                           {
+                                             "likedByCurrentUser": false,
+                                             "scrappedByCurrentUser": false,
+                                             "id": 4,
+                                             "title": "순두부 사과 소스 오이무침",
+                                             "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00032_2.png",
+                                             "categorySlowAging": "염증감소",
+                                             "categoryType": "한식",
+                                             "difficulty": "보통",
+                                             "totalTimeMinutes": 45,
+                                             "ingredientTagIds": [
+                                               175,
+                                               280,
+                                               1166,
+                                               1089
+                                             ],
+                                             "likes": 0
+                                           }
+                                         ],
+                                         "pageable": {
+                                           "pageNumber": 0,
+                                           "pageSize": 10,
+                                           "sort": {
+                                             "empty": false,
+                                             "sorted": true,
+                                             "unsorted": false
+                                           },
+                                           "offset": 0,
+                                           "paged": true,
+                                           "unpaged": false
+                                         },
+                                         "last": true,
+                                         "totalPages": 1,
+                                         "totalElements": 1,
+                                         "size": 10,
+                                         "number": 0,
+                                         "sort": {
+                                           "empty": false,
+                                           "sorted": true,
+                                           "unsorted": false
+                                         },
+                                         "numberOfElements": 1,
+                                         "first": true,
+                                         "empty": false
+                                       }
+                                     }
                                     """))),
             @ApiResponse(responseCode = "404", description = "레시피 없음",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
@@ -133,8 +332,10 @@ public interface RecipeApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "인기 검색어 조회 성공",
-                                      "data": true
+                                      "message": "인기 검색어 조회 성공 ",
+                                      "data": [
+                                        "사과"
+                                      ]
                                     }
                                     """)))
     })
@@ -153,7 +354,37 @@ public interface RecipeApi {
                                       "status": 200,
                                       "code": "200 OK",
                                       "message": "레시피 수정 성공",
-                                      "data": true
+                                      "data": {
+                                        "id": 49,
+                                        "email": "A@example.com",
+                                        "title": "닭가슴살 덮밥",
+                                        "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00281_1.png",
+                                        "description": "닭가슴살로 간단히 덮밥해먹기",
+                                        "categorySlowAging": "염증감소",
+                                        "categoryType": "한식",
+                                        "difficulty": "쉬움",
+                                        "timeHours": 0,
+                                        "timeMinutes": 45,
+                                        "ingredientTagIds": [
+                                          1
+                                        ],
+                                        "ingredients": {
+                                          "물": "2ml(1/3작은술)"
+                                        },
+                                        "seasoning": {
+                                          "설탕": "2g(1/3작은술)"
+                                        },
+                                        "stepDescriptions": [
+                                          "닭가슴살을 전자레인지에 데운다"
+                                        ],
+                                        "stepImageUrls": "http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_5.png",
+                                        "tips": "닭가슴살을 잘게 자를수록 더 맛있음",
+                                        "likes": 0,
+                                        "scraps": 0,
+                                        "createdAt": "2025-06-03T00:08:22.319638443",
+                                        "updatedAt": "2025-06-03T00:08:22.31966641",
+                                        "allergies": []
+                                      }
                                     }
                                     """))),
             @ApiResponse(responseCode = "404", description = "레시피 없음",
@@ -179,7 +410,7 @@ public interface RecipeApi {
                                       "status": 200,
                                       "code": "200 OK",
                                       "message": "레시피 삭제 성공",
-                                      "data": true
+                                      "data": "recipeId: 49 삭제 완료"
                                     }
                                     """))),
             @ApiResponse(responseCode = "404", description = "레시피 없음",
@@ -198,11 +429,20 @@ public interface RecipeApi {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "status": 200,
-                                      "code": "200 OK",
-                                      "message": "작성한 레시피를 최대 10개까지 조회 성공",
-                                      "data": true
-                                    }
+                                       "status": 200,
+                                       "code": "200 OK",
+                                       "message": "작성한 레시피 조회 성공",
+                                       "data": [
+                                         {
+                                           "recipeId": 50,
+                                           "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00032_2.png",
+                                           "title": "닭가슴살 덮밥",
+                                           "ingredientTags": [
+                                             2
+                                           ]
+                                         }
+                                       ]
+                                     }
                                     """)))
     })
     ResponseEntity<CommonResponse<List<RecipeSummaryResponse>>> getMyRecipes(

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeEventApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeEventApi.java
@@ -7,6 +7,7 @@ import BE_Elixir.Elixir.domain.recipe.dto.request.RecipeCommentUpdateRequestDTO;
 import BE_Elixir.Elixir.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -24,7 +25,23 @@ public interface RecipeEventApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "댓글 등록 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                          "status": 201,
+                                          "code": "201 CREATED",
+                                          "message": "댓글 등록 성공 ",
+                                          "data": {
+                                            "commentId": 3,
+                                            "recipeId": 1,
+                                            "nickName": "A",
+                                            "title": "칭호입니다",
+                                            "content": "댓글 등록하기",
+                                            "createdAt": "2025-06-03T00:42:28.932330511",
+                                            "updatedAt": "2025-06-03T00:42:28.932342665"
+                                          }
+                                        }
+                                    """))),
             @ApiResponse(responseCode = "500", description = "댓글 등록 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
@@ -39,7 +56,23 @@ public interface RecipeEventApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "댓글 수정 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                           "status": 200,
+                                           "code": "200 OK",
+                                           "message": "댓글 수정 성공",
+                                           "data": {
+                                             "commentId": 3,
+                                             "recipeId": 1,
+                                             "nickName": "A",
+                                             "title": "칭호입니다",
+                                             "content": "댓글 수정하기",
+                                             "createdAt": "2025-06-03T00:42:28.932331",
+                                             "updatedAt": "2025-06-03T00:45:42.514499224"
+                                           }
+                                         }
+                                    """))),
             @ApiResponse(responseCode = "500", description = "댓글 수정 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
@@ -55,7 +88,15 @@ public interface RecipeEventApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "댓글 삭제 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                            "status": 200,
+                                            "code": "200 OK",
+                                            "message": "댓글 삭제 성공",
+                                            "data": "commentId: 1 삭제 완료"
+                                          }
+                                    """))),
             @ApiResponse(responseCode = "500", description = "댓글 삭제 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
@@ -70,7 +111,15 @@ public interface RecipeEventApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "스크랩 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                          "status": 201,
+                                          "code": "201 CREATED",
+                                          "message": "레시피 스크랩 성공",
+                                          "data": "recipeId: 1"
+                                        }
+                                    """))),
             @ApiResponse(responseCode = "500", description = "스크랩 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
@@ -84,7 +133,15 @@ public interface RecipeEventApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "스크랩 취소 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                          "status": 200,
+                                          "code": "200 OK",
+                                          "message": "레시피 스크랩 취소 성공",
+                                          "data": "recipeId: 1"
+                                        }
+                                    """))),
             @ApiResponse(responseCode = "500", description = "스크랩 취소 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
@@ -98,7 +155,15 @@ public interface RecipeEventApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "좋아요 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                          "status": 201,
+                                          "code": "201 CREATED",
+                                          "message": "레시피 좋아요 성공",
+                                          "data": "recipeId: 1"
+                                        }
+                                    """))),
             @ApiResponse(responseCode = "500", description = "좋아요 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
@@ -112,7 +177,15 @@ public interface RecipeEventApi {
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "좋아요 취소 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                          "status": 200,
+                                          "code": "200 OK",
+                                          "message": "레시피 좋아요 취소 성공",
+                                          "data": "recipeId: 1"
+                                        }
+                                    """))),
             @ApiResponse(responseCode = "500", description = "좋아요 취소 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })

--- a/src/main/java/BE_Elixir/Elixir/domain/recommendation/controller/api/RecommendationApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recommendation/controller/api/RecommendationApi.java
@@ -28,8 +28,20 @@ public interface RecommendationApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "홈에서 추천 레시피 조회 성공",
-                                      "data": true
+                                      "message": "추천 레시피 조회 성공",
+                                      "data": [
+                                        {
+                                          "id": 50,
+                                          "title": "닭가슴살 덮밥",
+                                          "imageUrl": "https://image.com",
+                                          "categorySlowAging": "항산화강화",
+                                          "categoryType": "한식",
+                                          "ingredientTagIds": [
+                                            2
+                                          ],
+                                          "scrappedByCurrentUser": false
+                                        }
+                                      ]
                                     }
                                     """))),
             @ApiResponse(responseCode = "404", description = "레시피 없음",
@@ -48,9 +60,13 @@ public interface RecommendationApi {
                             examples = @ExampleObject(value = """
                                     {
                                       "status": 200,
-                                      "code": "200 OK",
+                                      "code": "OK",
                                       "message": "추천 검색어 조회 성공",
-                                      "data": true
+                                      "data": [
+                                        "닭가슴살",
+                                        "덮밥",
+                                        "곤약(구약나물)"
+                                      ]
                                     }
                                     """))),
             @ApiResponse(responseCode = "404", description = "레시피 없음",


### PR DESCRIPTION
## 📌 Issue Number
- #87 

## 🪐 작업 내용
- Swagger 문서의 data 필드에 실제 응답 예시 추가

## ✅ PR 상세 내용
아래 파일의 data 필드에 실제 응답 예시 추가
- RecipeApi
-  RecipeEventApi
-  RecommendationApi
-  ChallengeApi
-  MemberApi


## 📚 Reference
- X