### PR TITLE
fix: 레시피 댓글 등록 시 사용자의 칭호 누락 문제 해결

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeCommentResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeCommentResponseDTO.java
@@ -23,6 +23,7 @@ public class RecipeCommentResponseDTO {
         this.commentId = recipeEvent.getId();
         this.recipeId = recipeEvent.getRecipe().getId(); // 직접 접근
         this.nickName = recipeEvent.getMember().getNickname();
+        this.title = recipeEvent.getMember().getTitle();
         this.content = recipeEvent.getContent();
         this.createdAt = recipeEvent.getCreatedAt();
         this.updatedAt = recipeEvent.getUpdatedAt();


### PR DESCRIPTION
## 📌 Issue Number
- closed #3 

## 🪐 작업 내용
- 레시피 댓글 등록 시 사용자의 칭호 누락 문제 해결

## ✅ PR 상세 내용
- 레시피 댓글 등록 시 사용자의 칭호 누락 문제 해결

## 📚 Reference
- X