### PR TITLE
refactor: getUsername()을 getId()로 변경하여 사용자 식별 방식 통일 in MemberDetails

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -309,10 +309,10 @@ public class MemberController implements MemberApi {
     public ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getMyRecipes(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        String email = memberDetails.getUsername();
+        Long memberId = memberDetails.getId();
 
         try {
-            List<RecipeImageResponseDTO> recipes = memberService.getMyRecipes(email);
+            List<RecipeImageResponseDTO> recipes = memberService.getMyRecipes(memberId);
             return ResponseEntity.ok(CommonResponse.success(
                     HttpStatus.OK.value(), HttpStatus.OK.toString(), "내 레시피 조회 성공", recipes));
 
@@ -331,10 +331,10 @@ public class MemberController implements MemberApi {
     public ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getMyScrapRecipes(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        String email = memberDetails.getUsername();
+        Long memberId = memberDetails.getId();
 
         try {
-            List<RecipeImageResponseDTO> scrappedRecipes = memberService.getMyScrapRecipes(email);
+            List<RecipeImageResponseDTO> scrappedRecipes = memberService.getMyScrapRecipes(memberId);
 
             return ResponseEntity.ok(CommonResponse.success(
                     HttpStatus.OK.value(), HttpStatus.OK.toString(),
@@ -485,10 +485,10 @@ public class MemberController implements MemberApi {
     public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        String email = memberDetails.getUsername();
+        Long memberId = memberDetails.getId();
 
         try {
-            List<MemberAchievementResponseDTO> achievements = memberService.getAllAchievements(email);
+            List<MemberAchievementResponseDTO> achievements = memberService.getAllAchievements(memberId);
 
             return ResponseEntity.ok(CommonResponse.success(
                     HttpStatus.OK.value(), HttpStatus.OK.toString(),
@@ -507,10 +507,10 @@ public class MemberController implements MemberApi {
     public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        String email = memberDetails.getUsername();
+        Long memberId = memberDetails.getId();
 
         try {
-            List<MemberAchievementResponseDTO> top3Achievements = memberService.getTop3Achievements(email);
+            List<MemberAchievementResponseDTO> top3Achievements = memberService.getTop3Achievements(memberId);
 
             return ResponseEntity.ok(CommonResponse.success(
                     HttpStatus.OK.value(), HttpStatus.OK.toString(),

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberService.java
@@ -301,8 +301,8 @@ public class MemberService {
 
 
     // 로그인한 사용자가 업로드한 모든 레시피 조회하기
-    public List<RecipeImageResponseDTO> getMyRecipes(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public List<RecipeImageResponseDTO> getMyRecipes(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Recipe> recipes = recipeRepository.findAllByMember(member);
@@ -313,8 +313,8 @@ public class MemberService {
     }
 
     // 로그인한 사용자가 스크랩한 레시피 조회하기
-    public List<RecipeImageResponseDTO> getMyScrapRecipes(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public List<RecipeImageResponseDTO> getMyScrapRecipes(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<RecipeEvent> scraps = recipeEventRepository.findByMemberAndScrapFlagTrue(member);
@@ -328,8 +328,8 @@ public class MemberService {
     }
 
     // 로그인한 사용자의 모든 챌린지 업적 정보 조회
-    public List<MemberAchievementResponseDTO> getAllAchievements(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public List<MemberAchievementResponseDTO> getAllAchievements(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 전체 챌린지 조회 (연도/월 기준)
@@ -367,8 +367,8 @@ public class MemberService {
     }
 
     // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
-    public List<MemberAchievementResponseDTO> getTop3Achievements(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public List<MemberAchievementResponseDTO> getTop3Achievements(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new OccupiedException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<ChallengeAchievement> achievements = challengeAchievementRepository.findByMemberId(member.getId());


### PR DESCRIPTION
## 📌 Issue Number
- closed #93 

## 🪐 작업 내용
- getUsername()을 getId()로 변경하여 사용자 식별 방식 통일

## ✅ PR 상세 내용
- getUsername()을 getId()로 변경하여 사용자 식별 방식 통일

## 📚 Reference
- X