### PR TITLE
refactor: 레시피·챌린지 도메인 및 S3 예외 처리 통합 개선

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
@@ -35,16 +35,10 @@ public class ChallengeController implements ChallengeApi {
             @RequestPart(value = "image", required = false) MultipartFile image,
             @RequestPart(value = "grayImage", required = false) MultipartFile grayImage
     ) {
-        try {
-            ChallengeResponseDTO response = challengeService.registerChallenge(dto, image, grayImage);
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "챌린지 등록 완료", response));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "챌린지 등록 실패 - " + e.getMessage()));
-        }
+        ChallengeResponseDTO response = challengeService.registerChallenge(dto, image, grayImage);
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "챌린지 등록 완료", response));
     }
 
     // 연도 별 챌린지 조회하기

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/controller/ChallengeController.java
@@ -52,33 +52,20 @@ public class ChallengeController implements ChallengeApi {
     public ResponseEntity<CommonResponse<List<ChallengeListResponseDTO>>> getChallengesByYear(
             @PathVariable int year
     ) {
-        try {
-            List<ChallengeListResponseDTO> result = challengeService.getChallengesByYear(year);
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    year + "년도 챌린지 목록 조회 성공", result));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            year + "년도 챌린지 목록 조회 실패 - " + e.getMessage()));
-        }
-
+        List<ChallengeListResponseDTO> result = challengeService.getChallengesByYear(year);
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                year + "년도 챌린지 목록 조회 성공", result));
     }
     // 특정 챌린지 상세 조회하기
     @GetMapping("/{challengeId}")
     public ResponseEntity<CommonResponse<ChallengeDetailResponseDTO>> getChallengeDetail(
             @PathVariable Long challengeId
     ) {
-        try {
-            ChallengeDetailResponseDTO result = challengeService.getChallengeDetail(challengeId);
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "챌린지 상세 조회 성공", result));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "챌린지 상세 조회 실패 - " + e.getMessage()));
-        }
+        ChallengeDetailResponseDTO result = challengeService.getChallengeDetail(challengeId);
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "챌린지 상세 조회 성공", result));
     }
 
     // 로그인한 사용자의 현재 진행 상황 조회
@@ -86,17 +73,11 @@ public class ChallengeController implements ChallengeApi {
     public ResponseEntity<CommonResponse<ChallengeProgressResponseDTO>> getProgress(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try{
-            Member member = memberDetails.getMember();
-            ChallengeProgressResponseDTO dto = challengeAchievementService.getProgress(member.getId());
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    memberDetails.getUsername() + " 사용자의 현재 진행 상황 조회 성공", dto));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            memberDetails.getUsername() + " 사용자의 현재 진행 상황 조회 실패 - " + e.getMessage()));
-        }
+        Member member = memberDetails.getMember();
+        ChallengeProgressResponseDTO dto = challengeAchievementService.getProgress(member.getId());
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                memberDetails.getUsername() + " 사용자의 현재 진행 상황 조회 성공", dto));
     }
 
     // 챌린지 최종 완료 여부 조회
@@ -104,17 +85,11 @@ public class ChallengeController implements ChallengeApi {
     public ResponseEntity<CommonResponse<ChallengeCompletedResponseDTO>> getChallengeCompletion(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            ChallengeCompletedResponseDTO dto = challengeAchievementService.getChallengeCompletion(member.getId());
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "챌린지 최종 완료 여부 조회 성공", dto));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "챌린지 최종 완료 여부 조회 실패 - " + e.getMessage()));
-        }
+        Member member = memberDetails.getMember();
+        ChallengeCompletedResponseDTO dto = challengeAchievementService.getChallengeCompletion(member.getId());
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "챌린지 최종 완료 여부 조회 성공", dto));
     }
 
     // 로그인한 사용자의 이전 챌린지 진행 상황 조회
@@ -123,16 +98,10 @@ public class ChallengeController implements ChallengeApi {
             @AuthenticationPrincipal MemberDetails memberDetails,
             @PathVariable Long challengeId
     ) {
-        try{
-            Member member = memberDetails.getMember();
-            ChallengeProgressResponseDTO dto = challengeAchievementService.getBeforeProgress(member.getId(), challengeId);
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    memberDetails.getUsername() + " 사용자의 이전 챌린지 진행 상황 조회 성공", dto));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            memberDetails.getUsername() + " 사용자의 이전 챌린지 진행 상황 조회 실패 - " + e.getMessage()));
-        }
+        Member member = memberDetails.getMember();
+        ChallengeProgressResponseDTO dto = challengeAchievementService.getBeforeProgress(member.getId(), challengeId);
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                memberDetails.getUsername() + " 사용자의 이전 챌린지 진행 상황 조회 성공", dto));
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
@@ -6,8 +6,8 @@ import BE_Elixir.Elixir.domain.challenge.entity.Challenge;
 import BE_Elixir.Elixir.domain.challenge.entity.ChallengeAchievement;
 import BE_Elixir.Elixir.domain.challenge.repository.ChallengeAchievementRepository;
 import BE_Elixir.Elixir.domain.challenge.repository.ChallengeRepository;
+import BE_Elixir.Elixir.global.exception.CustomException;
 import BE_Elixir.Elixir.global.exception.ErrorCode;
-import BE_Elixir.Elixir.global.exception.OccupiedException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,7 +35,7 @@ public class ChallengeAchievementService {
         ChallengeAchievement achievement = createIfNotExists(memberId);
 
         Challenge challenge = challengeRepository.findById(achievement.getChallengeId())
-                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_NOT_FOUND));
 
         return ChallengeProgressResponseDTO.from(challenge, achievement);
     }
@@ -49,7 +49,7 @@ public class ChallengeAchievementService {
         // 현재 연도와 월에 해당하는 챌린지 조회
         Challenge challenge = challengeRepository
                 .findByYearAndMonth(year, month)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_NOT_FOUND));
 
         // 해당 챌린지와 회원 ID에 대한 챌린지 달성 정보 조회
         return challengeAchievementRepository
@@ -76,7 +76,7 @@ public class ChallengeAchievementService {
         ChallengeAchievement achievement = createIfNotExists(memberId);
 
         Challenge challenge = challengeRepository.findById(achievement.getChallengeId())
-                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_NOT_FOUND));
 
 
         // 세부 목표 8개 달성 여부
@@ -110,7 +110,7 @@ public class ChallengeAchievementService {
 
         Challenge challenge = challengeRepository
                 .findById(challengeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_NOT_FOUND));
 
         Optional<ChallengeAchievement> optionalAchievement =
                 challengeAchievementRepository.findByChallengeIdAndMemberId(challengeId, memberId);

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeService.java
@@ -33,19 +33,27 @@ public class ChallengeService {
             ChallengeRequestDTO dto,
             MultipartFile image,
             MultipartFile grayImage
-    ) throws IOException {
+    ) {
         Challenge challenge = ChallengeRequestDTO.from(dto);
 
         // 업적 컬러 이미지
         if (image != null && !image.isEmpty()) {
-            String imageUrl = s3Service.upload(image, "challenge/achievement-color");
-            challenge.setAchievementImageUrl(imageUrl);
+            try {
+                String imageUrl = s3Service.upload(image, "challenge/achievement-color");
+                challenge.setAchievementImageUrl(imageUrl);
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+            }
         }
 
         // 업적 흑백 이미지
         if (grayImage != null && !grayImage.isEmpty()) {
-            String grayImageUrl = s3Service.upload(grayImage, "challenge/achievement-gray");
-            challenge.setGrayAchievementImageUrl(grayImageUrl);
+            try {
+                String grayImageUrl = s3Service.upload(grayImage, "challenge/achievement-gray");
+                challenge.setGrayAchievementImageUrl(grayImageUrl);
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+            }
         }
 
         challengeRepository.save(challenge);

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeService.java
@@ -8,8 +8,8 @@ import BE_Elixir.Elixir.domain.challenge.entity.Challenge;
 import BE_Elixir.Elixir.domain.challenge.repository.ChallengeRepository;
 import BE_Elixir.Elixir.domain.ingredient.entity.Ingredient;
 import BE_Elixir.Elixir.domain.ingredient.repository.IngredientRepository;
+import BE_Elixir.Elixir.global.exception.CustomException;
 import BE_Elixir.Elixir.global.exception.ErrorCode;
-import BE_Elixir.Elixir.global.exception.OccupiedException;
 import BE_Elixir.Elixir.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -66,7 +66,7 @@ public class ChallengeService {
     @Transactional(readOnly = true)
     public ChallengeDetailResponseDTO getChallengeDetail(Long challengeId) {
         Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.CHALLENGE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_NOT_FOUND));
 
         // 챌린지 month
         int month = challenge.getMonth();

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
@@ -61,20 +61,13 @@ public class RecipeController implements RecipeApi {
             @PathVariable Long recipeId,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            RecipeDetailResponseDTO response = recipeService.getRecipeDetail(recipeId, member);
+        Member member = memberDetails.getMember();
+        RecipeDetailResponseDTO response = recipeService.getRecipeDetail(recipeId, member);
 
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "레시피 조회 성공", response
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 조회 실패 - " + e.getMessage()
-                    ));
-        }
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "레시피 조회 성공", response
+        ));
     }
 
     // 추후에 추천레시피 구현 후, 사용자 별 추천 레시피 내용 조회 추가
@@ -116,26 +109,18 @@ public class RecipeController implements RecipeApi {
             @RequestParam(required = false) CategorySlowAging categorySlowAging,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            // 검색어 저장
-            recipeService.saveSearchKeyword(keyword);
+        // 검색어 저장
+        recipeService.saveSearchKeyword(keyword);
 
-            Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-            Member member = memberDetails.getMember();
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Member member = memberDetails.getMember();
 
-            Page<RecipeHomeResponseDTO> response = recipeService.searchRecipe(keyword, pageable, categoryType, categorySlowAging, member);
+        Page<RecipeHomeResponseDTO> response = recipeService.searchRecipe(keyword, pageable, categoryType, categorySlowAging, member);
 
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "레시피 검색 성공", response
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(
-                            HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 검색 실패 - " + e.getMessage()
-                    ));
-        }
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "레시피 검색 성공", response
+        ));
     }
 
     // 추후에 추천 검색어 추가하기
@@ -144,20 +129,11 @@ public class RecipeController implements RecipeApi {
     public ResponseEntity<CommonResponse<?>> getSearchKeyword(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            List<String> popularKeywords = recipeService.getPopularSearchKeywords();
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "인기 검색어 조회 성공 ", popularKeywords
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(
-                            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                            HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "인기 검색어 조회 실패 - " + e.getMessage()
-                    ));
-        }
+        List<String> popularKeywords = recipeService.getPopularSearchKeywords();
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "인기 검색어 조회 성공 ", popularKeywords
+        ));
     }
 
     // 레시피 수정
@@ -189,19 +165,13 @@ public class RecipeController implements RecipeApi {
             @PathVariable Long recipeId,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            recipeService.deleteRecipe(recipeId, member);
+        Member member = memberDetails.getMember();
+        recipeService.deleteRecipe(recipeId, member);
 
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "레시피 삭제 성공", "recipeId: " + recipeId + " 삭제 완료"
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 삭제 실패 - " + e.getMessage()));
-        }
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "레시피 삭제 성공", "recipeId: " + recipeId + " 삭제 완료"
+        ));
     }
 
     // 로그인한 사용자가 작성한 레시피를 최대 10개까지 조회
@@ -210,19 +180,11 @@ public class RecipeController implements RecipeApi {
             @AuthenticationPrincipal MemberDetails memberDetails,
             @RequestParam(defaultValue = "10") int size
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            List<RecipeSummaryResponse> recipes = recipeService.getMyRecipes(member, size);
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "작성한 레시피 조회 성공", recipes
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(
-                            HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "작성한 레시피 조회 실패 - " + e.getMessage()
-                    ));
-        }
+        Member member = memberDetails.getMember();
+        List<RecipeSummaryResponse> recipes = recipeService.getMyRecipes(member, size);
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "작성한 레시피 조회 성공", recipes
+        ));
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
@@ -40,19 +40,12 @@ public class RecipeController implements RecipeApi {
             @RequestPart(value = "recipeStepImages", required = false) List<MultipartFile> recipeStepImages,
             @AuthenticationPrincipal MemberDetails memberDetails
     ){
-        try {
-            Member member = memberDetails.getMember();
-            RecipeResponseDTO response = recipeService.createRecipe(dto, image, recipeStepImages, member);
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.CREATED.toString(),
-                    "레시피 등록 성공", response
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 등록 실패 - " + e.getMessage()
-            ));
-        }
+        Member member = memberDetails.getMember();
+        RecipeResponseDTO response = recipeService.createRecipe(dto, image, recipeStepImages, member);
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.CREATED.toString(),
+                "레시피 등록 성공", response
+        ));
     }
 
     // 레시피 상세 조회
@@ -145,18 +138,12 @@ public class RecipeController implements RecipeApi {
             @RequestPart(value = "recipeStepImages", required = false) List<MultipartFile> recipeStepImages,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            RecipeResponseDTO response = recipeService.updateRecipe(recipeId, dto, image, recipeStepImages, member);
-            return ResponseEntity.ok(CommonResponse.success(
-                    HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                    "레시피 수정 성공", response
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 수정 실패 - " + e.getMessage()));
-        }
+        Member member = memberDetails.getMember();
+        RecipeResponseDTO response = recipeService.updateRecipe(recipeId, dto, image, recipeStepImages, member);
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "레시피 수정 성공", response
+        ));
     }
     
     // 레시피 삭제

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeEventController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeEventController.java
@@ -30,21 +30,14 @@ public class RecipeEventController implements RecipeEventApi {
             @RequestBody RecipeCommentCreateRequestDTO requestDTO,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            requestDTO.setRecipeId(recipeId);
-            RecipeCommentResponseDTO createdComment = recipeEventService.addComment(requestDTO, member);
+        Member member = memberDetails.getMember();
+        requestDTO.setRecipeId(recipeId);
+        RecipeCommentResponseDTO createdComment = recipeEventService.addComment(requestDTO, member);
 
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(),
-                            "댓글 등록 성공 ", createdComment
-                    ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "댓글 등록 실패 " + e.getMessage()
-                    ));
-        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(),
+                        "댓글 등록 성공 ", createdComment
+                ));
     }
 
     // 댓글 수정하기
@@ -55,22 +48,15 @@ public class RecipeEventController implements RecipeEventApi {
         @RequestBody RecipeCommentUpdateRequestDTO requestDTO,
         @AuthenticationPrincipal MemberDetails memberDetails
     ){
-        try {
-            Member member = memberDetails.getMember();
-            requestDTO.setRecipeId(recipeId);
-            requestDTO.setCommentId(commentId);
-            RecipeCommentResponseDTO editedComment = recipeEventService.editComment(requestDTO, member);
+        Member member = memberDetails.getMember();
+        requestDTO.setRecipeId(recipeId);
+        requestDTO.setCommentId(commentId);
+        RecipeCommentResponseDTO editedComment = recipeEventService.editComment(requestDTO, member);
 
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                            "댓글 수정 성공", editedComment
-                    ));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "댓글 수정 실패 " + e.getMessage()
-                    ));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                        "댓글 수정 성공", editedComment
+                ));
     }
 
     // 댓글 삭제하기
@@ -80,18 +66,12 @@ public class RecipeEventController implements RecipeEventApi {
             @PathVariable Long commentId,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            recipeEventService.deleteComment(commentId, member);
+        Member member = memberDetails.getMember();
+        recipeEventService.deleteComment(commentId, member);
 
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                            "댓글 삭제 성공", "commentId: " + commentId + " 삭제 완료"));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "댓글 삭제 실패 " + e.getMessage()));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                        "댓글 삭제 성공", "commentId: " + commentId + " 삭제 완료"));
     }
 
     // 스크랩하기
@@ -100,18 +80,12 @@ public class RecipeEventController implements RecipeEventApi {
             @PathVariable Long recipeId,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            recipeEventService.scrapRecipe(recipeId, member);
+        Member member = memberDetails.getMember();
+        recipeEventService.scrapRecipe(recipeId, member);
 
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(),
-                            "레시피 스크랩 성공", "recipeId: " + recipeId));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 스크랩 실패: " + e.getMessage()));
-        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(),
+                        "레시피 스크랩 성공", "recipeId: " + recipeId));
     }
 
     // 스크랩 취소하기
@@ -120,18 +94,12 @@ public class RecipeEventController implements RecipeEventApi {
             @PathVariable Long recipeId,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            recipeEventService.cancelScrapRecipe(recipeId, member);
+        Member member = memberDetails.getMember();
+        recipeEventService.cancelScrapRecipe(recipeId, member);
 
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                            "레시피 스크랩 취소 성공", "recipeId: " + recipeId));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 스크랩 취소 실패: " + e.getMessage()));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                        "레시피 스크랩 취소 성공", "recipeId: " + recipeId));
     }
 
     // 좋아요하기
@@ -140,18 +108,12 @@ public class RecipeEventController implements RecipeEventApi {
             @PathVariable Long recipeId,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            recipeEventService.likeRecipe(recipeId, member);
+        Member member = memberDetails.getMember();
+        recipeEventService.likeRecipe(recipeId, member);
 
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(),
-                            "레시피 좋아요 성공", "recipeId: " + recipeId));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 좋아요 실패: " + e.getMessage()));
-        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.success(HttpStatus.CREATED.value(), HttpStatus.CREATED.toString(),
+                        "레시피 좋아요 성공", "recipeId: " + recipeId));
     }
 
     // 좋아요 취소하기
@@ -160,17 +122,11 @@ public class RecipeEventController implements RecipeEventApi {
             @PathVariable Long recipeId,
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        try {
-            Member member = memberDetails.getMember();
-            recipeEventService.cancelLikeRecipe(recipeId, member);
+        Member member = memberDetails.getMember();
+        recipeEventService.cancelLikeRecipe(recipeId, member);
 
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                            "레시피 좋아요 취소 성공", "recipeId: " + recipeId));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-                            "레시피 좋아요 취소 실패: " + e.getMessage()));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                        "레시피 좋아요 취소 성공", "recipeId: " + recipeId));
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeEventService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeEventService.java
@@ -8,8 +8,8 @@ import BE_Elixir.Elixir.domain.recipe.entity.Recipe;
 import BE_Elixir.Elixir.domain.recipe.entity.RecipeEvent;
 import BE_Elixir.Elixir.domain.recipe.repository.RecipeEventRepository;
 import BE_Elixir.Elixir.domain.recipe.repository.RecipeRepository;
+import BE_Elixir.Elixir.global.exception.CustomException;
 import BE_Elixir.Elixir.global.exception.ErrorCode;
-import BE_Elixir.Elixir.global.exception.OccupiedException;
 import BE_Elixir.Elixir.global.s3.S3Service;
 import jakarta.transaction.Transactional;
 import lombok.*;
@@ -30,7 +30,7 @@ public class RecipeEventService {
     ) {
         // 레시피 존재 여부 확인
         Recipe recipe = recipeRepository.findById(requestDTO.getRecipeId())
-                .orElseThrow(() -> new OccupiedException(ErrorCode.RECIPE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         // 댓글 생성
         RecipeEvent comment = RecipeEvent.createRecipeComment(recipe, requestDTO, member);
@@ -47,11 +47,11 @@ public class RecipeEventService {
     ){
         // 기존 댓글 조회
         RecipeEvent existingComment = recipeEventRepository.findById(requestDTO.getCommentId())
-                .orElseThrow(() -> new OccupiedException(ErrorCode.COMMENT_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
         // 댓글 작성자가 아닌 경우 예외 처리
         if (!existingComment.getMember().getEmail().equals(member.getEmail())) {
-            throw new OccupiedException(ErrorCode.UNAUTHORIZED_OPERATION); // 수정 권한이 없으면 예외
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS); // 수정 권한이 없으면 예외
         }
 
         // 댓글 내용 수정
@@ -64,16 +64,16 @@ public class RecipeEventService {
     public void deleteComment(Long commentId, Member member) {
         // 기존 댓글 조회
         RecipeEvent existingComment = recipeEventRepository.findById(commentId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.COMMENT_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
         // 댓글 작성자가 아닌 경우 예외 처리
         if (!existingComment.getMember().getEmail().equals(member.getEmail())) {
-            throw new OccupiedException(ErrorCode.UNAUTHORIZED_OPERATION);
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
         }
 
         // 댓글(flag)이 맞는지 한 번 확인
         if (!existingComment.isCommentFlag()) {
-            throw new OccupiedException(ErrorCode.INVALID_OPERATION);
+            throw new CustomException(ErrorCode.INVALID_EVENT_OPERATION);
         }
 
         existingComment.setCommentFlag(false); // 댓글 플래그 끄기
@@ -87,12 +87,12 @@ public class RecipeEventService {
     public void scrapRecipe(Long recipeId, Member member) {
         // 레시피 존재 여부 확인
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.RECIPE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         // 기존에 스크랩한 게 있는지 확인
         boolean alreadyScrapped = recipeEventRepository.existsByRecipeIdAndMemberIdAndScrapFlagTrue(recipeId, member.getId());
         if (alreadyScrapped) {
-            throw new OccupiedException(ErrorCode.ALREADY_SCRAPPED);
+            throw new CustomException(ErrorCode.ALREADY_SCRAPPED);
         }
 
         RecipeEvent scrap = new RecipeEvent();
@@ -107,17 +107,17 @@ public class RecipeEventService {
     public void cancelScrapRecipe(Long recipeId, Member member) {
         // 스크랩한 거 가져오기
         RecipeEvent scrap = recipeEventRepository.findByRecipeIdAndMemberIdAndScrapFlagTrue(recipeId, member.getId())
-                .orElseThrow(() -> new OccupiedException(ErrorCode.SCRAP_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.SCRAP_NOT_FOUND));
 
 
         // 스크랩한 사용자가 아닌 경우 예외 처리
         if (!scrap.getMember().getEmail().equals(member.getEmail())) {
-            throw new OccupiedException(ErrorCode.UNAUTHORIZED_OPERATION);
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
         }
 
         // 스크랩(flag)이 맞는지 한 번 확인
         if (!scrap.isScrapFlag()) {
-            throw new OccupiedException(ErrorCode.INVALID_OPERATION);
+            throw new CustomException(ErrorCode.INVALID_EVENT_OPERATION);
         }
 
         scrap.setScrapFlag(false); // 스크랩 플래그 끄기
@@ -130,12 +130,12 @@ public class RecipeEventService {
     public void likeRecipe(Long recipeId, Member member) {
         // 레시피 존재 여부 확인
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.RECIPE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         // 기존에 좋아요한 게 있는지 확인
         boolean alreadyLiked = recipeEventRepository.existsByRecipeIdAndMemberIdAndLikeFlagTrue(recipeId, member.getId());
         if (alreadyLiked) {
-            throw new OccupiedException(ErrorCode.ALREADY_LIKED);
+            throw new CustomException(ErrorCode.ALREADY_LIKED);
         }
 
         RecipeEvent like = new RecipeEvent();
@@ -152,16 +152,16 @@ public class RecipeEventService {
     @Transactional
     public void cancelLikeRecipe(Long recipeId, Member member) {
         RecipeEvent like = recipeEventRepository.findByRecipeIdAndMemberIdAndLikeFlagTrue(recipeId, member.getId())
-                .orElseThrow(() -> new OccupiedException(ErrorCode.LIKE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.LIKE_NOT_FOUND));
 
         // 좋아요한 사용자가 아닌 경우 예외 처리
         if (!like.getMember().getEmail().equals(member.getEmail())) {
-            throw new OccupiedException(ErrorCode.UNAUTHORIZED_OPERATION);
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
         }
 
         // 좋아요(flag)가 맞는지 한 번 확인
         if (!like.isLikeFlag()) {
-            throw new OccupiedException(ErrorCode.INVALID_OPERATION);
+            throw new CustomException(ErrorCode.INVALID_EVENT_OPERATION);
         }
 
         like.setLikeFlag(false); // 좋아요 플래그 끄기

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
@@ -14,8 +14,8 @@ import BE_Elixir.Elixir.domain.recipe.repository.RecipeEventRepository;
 import BE_Elixir.Elixir.domain.recipe.repository.RecipeRepository;
 import BE_Elixir.Elixir.global.enums.CategorySlowAging;
 import BE_Elixir.Elixir.global.enums.CategoryType;
+import BE_Elixir.Elixir.global.exception.CustomException;
 import BE_Elixir.Elixir.global.exception.ErrorCode;
-import BE_Elixir.Elixir.global.exception.OccupiedException;
 import BE_Elixir.Elixir.global.redis.RedisRecipeService;
 import BE_Elixir.Elixir.global.s3.S3Service;
 import org.springframework.context.ApplicationEventPublisher;
@@ -99,7 +99,7 @@ public class RecipeService {
     // 레시피 조회
     public RecipeResponseDTO getRecipe(Long recipeId) {
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.RECIPE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         return new RecipeResponseDTO(recipe);
     }
@@ -109,7 +109,7 @@ public class RecipeService {
     public RecipeDetailResponseDTO getRecipeDetail(Long recipeId, Member member) {
         // 레시피 조회
         Recipe recipe = recipeRepository.findWithAllById(recipeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.RECIPE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         // 레시피 작성자
         Member authorRecipe = recipe.getMember();
@@ -223,10 +223,10 @@ public class RecipeService {
     ) throws IOException {
         // 레시피 조회
         Recipe recipe = recipeRepository.findWithAllById(recipeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.RECIPE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         if (!recipe.getMember().getEmail().equals(member.getEmail())){
-            throw new OccupiedException(ErrorCode.UNAUTHORIZED_OPERATION); // 권한 체크
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS); // 권한 체크
         }
 
         // 기본 필드 업데이트
@@ -271,11 +271,11 @@ public class RecipeService {
     @Transactional
     public void deleteRecipe(Long recipeId, Member member) {
         Recipe recipe = recipeRepository.findWithAllById(recipeId)
-                .orElseThrow(() -> new OccupiedException(ErrorCode.RECIPE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         // 작성자 본인만 삭제 가능
         if (!recipe.getMember().getEmail().equals(member.getEmail())) {
-            throw new OccupiedException(ErrorCode.UNAUTHORIZED_OPERATION);
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
         }
 
         // 레시피에 달린 댓글 먼저 삭제

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
@@ -53,22 +53,30 @@ public class RecipeService {
             MultipartFile image,
             List<MultipartFile> recipeStepImages,
             Member member
-    ) throws IOException {
+    ) {
         // 기본 필드 세팅
         Recipe recipe = Recipe.from(dto, member);
 
-        // 대표 이미지 업로드
+        // 대표 이미지 업로드 (IOException을 CustomException으로 변환)
         if (image != null && !image.isEmpty()) {
-            String imageUrl = s3Service.upload(image, "recipe/main");
-            recipe.setImageUrl(imageUrl);
+            try {
+                String imageUrl = s3Service.upload(image, "recipe/main");
+                recipe.setImageUrl(imageUrl);
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+            }
         }
 
         // 단계별 이미지 업로드
         if (recipeStepImages != null && !recipeStepImages.isEmpty()) {
             List<String> stepUrls = new ArrayList<>();
             for (MultipartFile file : recipeStepImages) {
-                String url = s3Service.upload(file, "recipe/steps");
-                stepUrls.add(url);
+                try {
+                    String url = s3Service.upload(file, "recipe/steps");
+                    stepUrls.add(url);
+                } catch (IOException e) {
+                    throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+                }
             }
             recipe.setStepImageUrls(stepUrls);
         }
@@ -220,7 +228,7 @@ public class RecipeService {
             MultipartFile image,
             List<MultipartFile> recipeStepImages,
             Member member
-    ) throws IOException {
+    ) {
         // 레시피 조회
         Recipe recipe = recipeRepository.findWithAllById(recipeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
@@ -234,21 +242,28 @@ public class RecipeService {
 
         // 대표 이미지 업데이트
         if (image != null && !image.isEmpty()) {
-            String imageUrl = s3Service.upload(image, "recipe/main");
-            recipe.setImageUrl(imageUrl);
+            try {
+                String imageUrl = s3Service.upload(image, "recipe/main");
+                recipe.setImageUrl(imageUrl);
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+            }
         }
 
         // 단계 이미지 업데이트
         if (recipeStepImages != null && !recipeStepImages.isEmpty()) {
             List<String> stepUrls = new ArrayList<>();
             for (MultipartFile file : recipeStepImages) {
-                String url = s3Service.upload(file, "recipe/steps");
-                stepUrls.add(url);
+                try {
+                    String url = s3Service.upload(file, "recipe/steps");
+                    stepUrls.add(url);
+                } catch (IOException e) {
+                    throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+                }
             }
             if (!stepUrls.isEmpty()) {
                 recipe.setStepImageUrls(stepUrls);
             }
-            recipe.setStepImageUrls(stepUrls);
         }
 
         recipe.getIngredientTags().clear(); // 참조 유지

--- a/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "좋아요한 레시피가 없습니다."),
     ALREADY_SCRAPPED(HttpStatus.CONFLICT.value(), "이미 스크랩한 레시피입니다."),
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "스크랩한 레시피가 없습니다."),
+    INVALID_EVENT_OPERATION(HttpStatus.BAD_REQUEST.value(), "잘못된 이벤트 요청입니다."),
 
     // 챌린지
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "챌린지를 찾을 수 없습니다."),

--- a/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
@@ -69,7 +69,7 @@ public enum ErrorCode {
     S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "MultipartFile을 File로 전환하지 못했습니다."),
     S3_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "S3에서 파일을 삭제하지 못했습니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "업로드하는 이미지의 용량이 초과되었습니다. (10MB미만)"),
-
+    S3_INVALID_URL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 S3 이미지 URL입니다.")
     ;
 
 

--- a/src/main/java/BE_Elixir/Elixir/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.io.IOException;
+
 @Slf4j
 @RestControllerAdvice
 @Order(value = Integer.MAX_VALUE)
@@ -23,4 +25,16 @@ public class GlobalExceptionHandler {
                         "서버 내부 오류가 발생했습니다."
                 ));
     }
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<CommonResponse<Void>> handleIOException(IOException e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CommonResponse.error(
+                        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        "IO_ERROR",
+                        "입출력 오류가 발생했습니다."
+                ));
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/global/exception/RestApiExceptionHandler.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/RestApiExceptionHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -23,4 +24,15 @@ public class RestApiExceptionHandler {
     }
 
     // 그외 시스템 에러는 이 아래에 각자 구현
+    // 파일 용량 초과 예외
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<CommonResponse<?>> handleMaxSizeException(MaxUploadSizeExceededException ex) {
+        return ResponseEntity
+                .status(ErrorCode.FILE_SIZE_EXCEEDED.getStatus())
+                .body(CommonResponse.error(
+                        ErrorCode.FILE_SIZE_EXCEEDED.getStatus(),
+                        ErrorCode.FILE_SIZE_EXCEEDED.name(),
+                        ErrorCode.FILE_SIZE_EXCEEDED.getMessage()
+                ));
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/global/s3/S3Service.java
+++ b/src/main/java/BE_Elixir/Elixir/global/s3/S3Service.java
@@ -1,5 +1,7 @@
 package BE_Elixir.Elixir.global.s3;
 
+import BE_Elixir.Elixir.global.exception.CustomException;
+import BE_Elixir.Elixir.global.exception.ErrorCode;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -30,7 +32,7 @@ public class S3Service {
     public String upload(MultipartFile multipartFile, String dirName) throws IOException {
 
         File uploadFile = convert(multipartFile)
-                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
+                .orElseThrow(() -> new CustomException(ErrorCode.S3_UPLOAD_ERROR));
         return upload(uploadFile, dirName);
     }
 
@@ -76,13 +78,12 @@ public class S3Service {
     // S3 버킷에서 파일 삭제
     public void deleteS3(String imageUrl, String dirName) {
         String fileName = extractFileName(imageUrl, dirName);
-
         try {
             amazonS3Client.deleteObject(bucket, fileName);
             log.info("파일 삭제 성공: {}", fileName);
         } catch (Exception e) {
             log.error("파일 삭제 실패: {}", fileName, e);
-            throw new RuntimeException("S3에서 파일 삭제 실패", e);
+            throw new CustomException(ErrorCode.S3_DELETE_ERROR);
         }
     }
 
@@ -91,7 +92,7 @@ public class S3Service {
     private String extractFileName(String imageUrl, String dirName) {
         int index = imageUrl.indexOf(dirName + "/");
         if (index == -1) {
-            throw new IllegalArgumentException("잘못된 S3 이미지 URL입니다: " + imageUrl);
+            throw new CustomException(ErrorCode.S3_INVALID_URL);
         }
         return imageUrl.substring(index);
     }


### PR DESCRIPTION
## 📌 Issue Number
- #18

## 🪐 작업 내용
- 챌린지/레시피 도메인과 S3 업로드 및 삭제 로직에 CustomException 기반 예외 처리 적용
- 레시피 등록 및 수정 시 이미지 업로드 실패에 대한 예외 처리 추가
- 챌린지 등록 시 업적 이미지 업로드 실패에 대한 예외 처리 추가
- ErrorCode에 S3 관련 예외 코드 (S3_INVALID_URL) 추가
- GlobalExceptionHandler에 IOException 전역 처리 추가

## ✅ PR 상세 내용
- 기존 MultipartFile 처리 중 S3 업로드가 실패할 경우의 예외를 try-catch로 감싸고, CustomException을 던지도록 변경
- 레시피 단계 이미지 업로드, 챌린지 업적 컬러/흑백 이미지 업로드 등 S3 관련 업로드에 예외 처리 적용
- GlobalExceptionHandler에 IOException 핸들러 추가

## 📚 Reference
- X