### PR TITLE
feat: jwt 인증 필터 응답 일관화 및 리팩토링

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/BE_Elixir/Elixir/global/security/JwtAuthenticationFilter.java
@@ -1,10 +1,13 @@
 package BE_Elixir.Elixir.global.security;
 
+import BE_Elixir.Elixir.global.response.CommonResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -24,49 +27,63 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     private final JwtProvider jwtProvider;
     private final String[] whitelist;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
         HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
         String requestURI = httpRequest.getRequestURI();
 
         // 허용 경로는 필터 건너뛰기
-        for (String pattern : whitelist) {
-            if (pathMatcher.match(pattern, requestURI)) {
-                // 확인용
-                log.info("Whitelist 패턴에 일치: {}, URI: {}", pattern, requestURI);
-                chain.doFilter(request, response);
-                return;
-            }
+        if (isWhitelisted(requestURI)) {
+            log.info("Whitelist 패턴에 일치: URI = {}", requestURI);
+            chain.doFilter(request, response);
+            return;
         }
 
-        // 1. Request Header 에서 JWT 토큰(Access Token) 추출
+        // Request Header 에서 JWT 토큰(Access Token) 추출
         String token = resolveToken((HttpServletRequest) request);
 
+        // JWT 토큰 검증 및 예외 처리
         if (token == null) {
             log.warn("Authorization 헤더에서 JWT 토큰을 찾을 수 없습니다.");
-        } else if (!jwtProvider.validateToken(token)) {
-            log.warn("유효하지 않거나 만료된 JWT 토큰이 요청에 포함되어 있습니다.");
+            sendErrorResponse(httpResponse, 401, "UNAUTHORIZED", "Authorization 헤더에서 JWT 토큰을 찾을 수 없습니다.");
+            return;
         }
 
-        // 2. validationToken()으로 토큰 유효성 검사
-        if (token != null && jwtProvider.validateToken(token)) {
-            try {
-                // 토큰이 유효할 경우 토큰에서 Authentication 객체를 갖고 와서 SecurityContext에 저장
-                Authentication authentication = jwtProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.info("JWT 토큰 인증 성공: {}", token);
-            } catch (Exception e) {
-                // 인증 실패시 예외 처리
-                log.error("JWT 인증 실패", e);
-                SecurityContextHolder.clearContext();
+        if (!jwtProvider.validateToken(token)) {
+            log.warn("유효하지 않거나 만료된 JWT 토큰이 요청에 포함되어 있습니다.");
+            sendErrorResponse(httpResponse, 401, "UNAUTHORIZED", "유효하지 않거나 만료된 JWT 토큰이 요청에 포함되어 있습니다.");
+            return;
+        }
 
-            }
-        } else {
-            log.warn("유효하지 않거나 만료된 토큰입니다.");
+        // 토큰이 유효할 경우 토큰에서 Authentication 객체를 갖고 와 SecurityContext 에 저장
+        try {
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("JWT 토큰 인증 성공: {}", token);
+        } catch (Exception e) {
+            // 인증 실패시 예외 처리
+            log.error("JWT 인증 실패", e);
+            SecurityContextHolder.clearContext();
+            sendErrorResponse(httpResponse, 401, "UNAUTHORIZED", "JWT 인증 중 오류가 발생했습니다.");
+            return;
         }
 
         chain.doFilter(request, response);
+    }
+
+    // 허용된 경로인지 확인
+    private boolean isWhitelisted(String requestURI) {
+        for (String pattern : whitelist) {
+            if (pathMatcher.match(pattern, requestURI)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // Request Header 에서 토큰 정보 추출
@@ -76,5 +93,17 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    // 응답 생성 메서드
+    private void sendErrorResponse(HttpServletResponse response, int status, String code, String message) throws IOException {
+        CommonResponse<?> errorResponse = CommonResponse.error(status, code, message);
+
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
     }
 }


### PR DESCRIPTION
## 📌 Issue Number
- closed #103 

## 🪐 작업 내용
- jwt 인증 필터 응답 일관화
- jwt 인증 필터 내 중복 기능 함수화

## ✅ PR 상세 내용
- jwt 인증 필터 응답 일관화
    - 기존에 필터에서 응답 실패 시, "UNAUTHORIZE" 만 반환되었던 것을 우리가 기존에 정의한 CommonResponse 형태에 맞게 반환하도록 수정
   ![image](https://github.com/user-attachments/assets/dad38d5e-2ba1-40d5-8d1b-0f77cbfdab74)
- jwt 인증 필터 내 중복 기능 함수화  
   - 인증 실패 시 응답 생성 기능 함수화

## 📚 Reference
- X