### PR TITLE
feat: error handler에 order 추가 

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,6 @@
 package BE_Elixir.Elixir.global.exception;
 
 import BE_Elixir.Elixir.global.response.CommonResponse;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
@@ -11,9 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.security.NoSuchAlgorithmException;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/BE_Elixir/Elixir/global/exception/RestApiExceptionHandler.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/RestApiExceptionHandler.java
@@ -2,16 +2,16 @@ package BE_Elixir.Elixir.global.exception;
 
 import BE_Elixir.Elixir.global.response.CommonResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import java.io.UnsupportedEncodingException;
 
 @Slf4j
 @RestControllerAdvice
+@Order(value = 1)
 public class RestApiExceptionHandler {
 
     @ExceptionHandler(CustomException.class)


### PR DESCRIPTION
## 📌 Issue Number
- closed #18  

## 🪐 작업 내용
- CustomExceptoon을 처리하는 `RestApiExceptionHandler` 에 `@Order` 가 정의되어 있지 않아 모든 Exception을  `GlobalExceptionHandler` 에서 잡아 처리하는 문제 발생 -> `RestApiExceptionHandler` 가 더 높은 우선순위를 갖도록 추가

## ✅ PR 상세 내용
- `RestApiExceptionHandler` 에 `@Order` 정의
- 불필요한 주석 제거 

## 📚 Reference
- X