### PR TITLE
feat: 레시피 댓글 응답에 작성자의 프로필 URL 필드 추가

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeCommentResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeCommentResponseDTO.java
@@ -14,6 +14,7 @@ public class RecipeCommentResponseDTO {
     private Long recipeId;
     private String nickName; // 댓글 작성자의 닉네임
     private String title; // 댓글 작성자의 칭호
+    private String authorProfileUrl; // 댓글 작성자의 프로필이미지
 
     private String content;
     private LocalDateTime createdAt;
@@ -24,6 +25,7 @@ public class RecipeCommentResponseDTO {
         this.recipeId = recipeEvent.getRecipe().getId(); // 직접 접근
         this.nickName = recipeEvent.getMember().getNickname();
         this.title = recipeEvent.getMember().getTitle();
+        this.authorProfileUrl = recipeEvent.getMember().getProfileUrl();
         this.content = recipeEvent.getContent();
         this.createdAt = recipeEvent.getCreatedAt();
         this.updatedAt = recipeEvent.getUpdatedAt();


### PR DESCRIPTION
## 📌 Issue Number
- closed #3

## 🪐 작업 내용
- 레시피 댓글 응답에 작성자의 프로필 URL 필드 추가

## ✅ PR 상세 내용
- RecipeCommentResponseDTO에 댓글 작성자의 프로필이미지(authorProfileUrl) 필드 추가

## 📚 Reference
- X