### PR TITLE
feat: 식단 유형(타입) 중복 검증 로직 추가

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/dietLog/repository/DietLogRepository.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/dietLog/repository/DietLogRepository.java
@@ -13,6 +13,10 @@ import java.util.List;
 @Repository
 public interface DietLogRepository extends JpaRepository<DietLog, Long> {
 
+    // 식단 기록 시, 그날 해당 타입으로 기록된 식단이 있는지 여부
+    boolean existsByMemberIdAndTypeAndTimeBetween(Long memberId, DietLogType type, LocalDateTime start, LocalDateTime end);
+    boolean existsByMemberIdAndTypeAndTimeBetweenAndIdNot(Long memberId, DietLogType type, LocalDateTime start, LocalDateTime end, Long id);
+
     // 특정 사용자의 특정 날짜 식단 전체 조회
     List<DietLog> findAllByMemberIdAndTimeBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/BE_Elixir/Elixir/domain/dietLog/service/DietLogService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/dietLog/service/DietLogService.java
@@ -43,6 +43,8 @@ public class DietLogService {
     private final S3Service s3Service;
     private final ApplicationEventPublisher eventPublisher;
 
+
+
     // 식단 기록하기
     public DietLogResponseDTO createDietLog(DietLogRequestDTO dto, Long memberId, MultipartFile image) {
 
@@ -50,8 +52,9 @@ public class DietLogService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다. member id: " + memberId));
 
-        // 식단 타입을 enum 타입으로 변환
+        // 식단 타입을 enum 타입으로 변환 및 검사
         DietLogType typeEnum = DietLogType.valueOf(dto.getType().toUpperCase());
+        validateDuplicateDietLogType(memberId, typeEnum, dto.getTime());
 
         // 객체 생성
         DietLog dietLog = dto.toEntity(typeEnum, member);
@@ -125,6 +128,15 @@ public class DietLogService {
         // 식단 타입 수정
         if (dto.getType() != null) {
             DietLogType typeEnum = DietLogType.valueOf(dto.getType().toUpperCase());
+
+            // 타입 중복 검사
+            if (dto.getTime() != null) {
+                validateDuplicateDietLogType(memberId, typeEnum, dto.getTime(), dietLogId);
+            }
+            else {
+                LocalDateTime time = dietLog.getTime();
+                validateDuplicateDietLogType(memberId, typeEnum, time, dietLogId);
+            }
             dietLog.setType(typeEnum);
         }
 
@@ -220,4 +232,42 @@ public class DietLogService {
                 .map(DietLog::convertToResponseDTO)
                 .toList();
     }
+
+    // 중복 식사 타입 검사 (create인 경우)
+    private void validateDuplicateDietLogType(Long memberId, DietLogType typeEnum, LocalDateTime time) {
+        if (typeEnum == DietLogType.간식) return;
+
+        LocalDate date = time.toLocalDate();
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+        // 중복 검사 시 현재 수정 대상은 제외
+        boolean exists = dietLogRepository.existsByMemberIdAndTypeAndTimeBetween(
+                memberId, typeEnum, startOfDay, endOfDay
+        );
+
+        if (exists) {
+            throw new CustomException(ErrorCode.DIET_LOG_TYPE_DUPLICATE);
+        }
+    }
+
+    // 중복 식사 타입 검사 (update인 경우)
+    private void validateDuplicateDietLogType(Long memberId, DietLogType typeEnum, LocalDateTime time, Long excludeDietLogId) {
+        if (typeEnum == DietLogType.간식) return;
+
+        LocalDate date = time.toLocalDate();
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+        // 중복 검사 시 현재 수정 대상은 제외
+        boolean exists = dietLogRepository.existsByMemberIdAndTypeAndTimeBetweenAndIdNot(
+                memberId, typeEnum, startOfDay, endOfDay, excludeDietLogId
+        );
+
+        if (exists) {
+            throw new CustomException(ErrorCode.DIET_LOG_TYPE_DUPLICATE);
+        }
+    }
+
+
 }

--- a/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     // 식단
     DIETLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "식단 기록이 존재하지 않습니다."),
     INVALID_DIETLOG_TYPE(HttpStatus.BAD_REQUEST.value(), "잘못된 식단 타입(아침, 점심 등)입니다."),
+    DIET_LOG_TYPE_DUPLICATE(HttpStatus.BAD_REQUEST.value(), "오늘은 이미 해당 식사 유형을 기록하셨습니다."),
 
     // 레시피
     RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "레시피가 존재하지 않습니다."),


### PR DESCRIPTION
## 📌 Issue Number
- closed #16

## 🪐 작업 내용
- 식단 기록, 수정 시 간식 제외 유형(아침, 점심, 저녁)이 중복되지 않도록 검증 로직 추가

## ✅ PR 상세 내용
- 만약 중복될 경우 400 에러 반환하도록 구현
![image](https://github.com/user-attachments/assets/9727cc8d-e675-417b-b079-0d4d2b8256cc)


## 📚 Reference
- X