### PR TITLE
feat: 레시피 상세 조회 응답에 레시피 작성자의 프로필 URL 필드 추가

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
@@ -101,12 +101,24 @@ public interface RecipeApi {
                                       "message": "레시피 조회 성공",
                                       "data": {
                                         "authorFollowByCurrentUser": false,
-                                        "comments": [],
-                                        "likedByCurrentUser": false,
-                                        "scrappedByCurrentUser": false,
-                                        "id": 3,
-                                        "authorNickname": "mj",
-                                        "authorTitle": null,
+                                            "comments": [
+                                              {
+                                                "commentId": 1,
+                                                "recipeId": 1,
+                                                "nickName": "mj",
+                                                "title": "비타민 수호자",
+                                                "authorProfileUrl": "https://commentPostUserImage.com",
+                                                "content": "mj로 댓글달기",
+                                                "createdAt": "2025-06-17T07:52:47",
+                                                "updatedAt": "2025-06-17T07:52:47"
+                                              }
+                                            ],
+                                            "likedByCurrentUser": false,
+                                            "scrappedByCurrentUser": false,
+                                            "id": 1,
+                                            "authorNickname": "mj",
+                                            "authorTitle": "비타민 수호자",
+                                            "authorProfileUrl": "https://recipePostUserImage.com",
                                         "title": "방울토마토 소박이",
                                         "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00031_1.png",
                                         "description": "기타",

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeDetailResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeDetailResponseDTO.java
@@ -21,6 +21,7 @@ public class RecipeDetailResponseDTO {
     private Long id;
     private String authorNickname; // 작성자의 닉네임
     private String authorTitle; // 작성자의 칭호
+    private String authorProfileUrl; // 레시피 작성자의 프로필이미지
     private Boolean authorFollowByCurrentUser; // 현재 사용자가 작성자를 팔로우했는지 여부
     private String title;
     private String imageUrl;
@@ -56,6 +57,7 @@ public class RecipeDetailResponseDTO {
         this.id = recipe.getId();
         this.authorNickname = recipe.getMember().getNickname();
         this.authorTitle = recipe.getMember().getTitle();
+        this.authorProfileUrl = recipe.getMember().getProfileUrl();
         this.authorFollowByCurrentUser = authorFollowByCurrentUser;
         this.title = recipe.getTitle();
         this.imageUrl = recipe.getImageUrl();


### PR DESCRIPTION
## 📌 Issue Number
- closed #3

## 🪐 작업 내용
- 레시피 상세 조회 응답에 레시피 작성자의 프로필 URL 필드 추가

## ✅ PR 상세 내용
- RecipeDetailResponseDTO에 레시피 작성자의 프로필이미지(authorProfileUrl) 필드 추가

## 📚 Reference
- X