### PR TITLE
feat: 레시피 등록 시 RecipeDetailResponseDTO를 반환하도록 수정하고, 댓글 API를 분리

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeController.java
@@ -41,7 +41,7 @@ public class RecipeController implements RecipeApi {
             @AuthenticationPrincipal MemberDetails memberDetails
     ){
         Member member = memberDetails.getMember();
-        RecipeResponseDTO response = recipeService.createRecipe(dto, image, recipeStepImages, member);
+        RecipeDetailResponseDTO response = recipeService.createRecipe(dto, image, recipeStepImages, member);
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.CREATED.toString(),
                 "레시피 등록 성공", response

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeEventController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/RecipeEventController.java
@@ -15,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 @RequestMapping("/api/recipe")
@@ -22,6 +24,19 @@ import org.springframework.web.bind.annotation.*;
 public class RecipeEventController implements RecipeEventApi {
 
     private final RecipeEventService recipeEventService;
+
+    // 레시피별 댓글 조회
+    @GetMapping("/{recipeId}/comment")
+    public ResponseEntity<CommonResponse<List<RecipeCommentResponseDTO>>> getCommentsByRecipeId(
+            @PathVariable Long recipeId
+    ) {
+        List<RecipeCommentResponseDTO> comments = recipeEventService.getCommentsByRecipeId(recipeId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                        "댓글 조회 성공", comments
+                ));
+    }
 
     // 댓글 등록하기
     @PostMapping("/{recipeId}/comment")

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeApi.java
@@ -38,12 +38,15 @@ public interface RecipeApi {
                                       "code": "201 CREATED",
                                       "message": "레시피 등록 성공",
                                       "data": {
-                                        "id": 49,
-                                        "email": "A@example.com",
+                                        "authorFollowByCurrentUser": false,
+                                        "likedByCurrentUser": false,
+                                        "scrappedByCurrentUser": false,
+                                        "id": 181,
+                                        "authorId": 1,
                                         "title": "닭가슴살 덮밥",
-                                        "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00281_1.png",
-                                        "description": "닭가슴살로 간단히 덮밥해먹기",
-                                        "categorySlowAging": "염증감소",
+                                        "imageUrl": "http://foodsafetykorea/food.jpg",
+                                        "description": "굽기",
+                                        "categorySlowAging": "항산화강화",
                                         "categoryType": "한식",
                                         "difficulty": "쉬움",
                                         "timeHours": 0,
@@ -51,19 +54,27 @@ public interface RecipeApi {
                                         "ingredientTagIds": [
                                           1
                                         ],
-                                        "ingredients": {
-                                          "물": "2ml(1/3작은술)"
-                                        },
-                                        "seasoning": {
-                                          "설탕": "2g(1/3작은술)"
-                                        },
+                                        "ingredients": [
+                                           {
+                                             "name": "닭",
+                                             "value": "1",
+                                             "unit": "마리"
+                                           }
+                                         ],
+                                         "seasonings": [
+                                           {
+                                             "name": "설탕",
+                                             "value": "1",
+                                             "unit": "T"
+                                           }
+                                         ],
                                         "stepDescriptions": [
                                           "닭가슴살을 전자레인지에 데운다"
                                         ],
                                         "stepImageUrls": "http://www.foodsafetykorea.go.kr/uploadimg/cook/20_00031_5.png",
                                         "tips": "닭가슴살을 잘게 자를수록 더 맛있음",
                                         "likes": 0,
-                                        "scraps": 0,
+                                        "scraps": 50,
                                         "createdAt": "2025-06-03T00:08:22.319638443",
                                         "updatedAt": "2025-06-03T00:08:22.31966641",
                                         "allergies": []
@@ -101,30 +112,15 @@ public interface RecipeApi {
                                       "message": "레시피 조회 성공",
                                       "data": {
                                         "authorFollowByCurrentUser": false,
-                                            "comments": [
-                                              {
-                                                "commentId": 1,
-                                                "recipeId": 1,
-                                                "nickName": "mj",
-                                                "title": "비타민 수호자",
-                                                "authorProfileUrl": "https://commentPostUserImage.com",
-                                                "content": "mj로 댓글달기",
-                                                "createdAt": "2025-06-17T07:52:47",
-                                                "updatedAt": "2025-06-17T07:52:47"
-                                              }
-                                            ],
-                                            "likedByCurrentUser": false,
-                                            "scrappedByCurrentUser": false,
-                                            "id": 1,
-                                            "authorNickname": "mj",
-                                            "authorTitle": "비타민 수호자",
-                                            "authorId": 1,
-                                            "authorProfileUrl": "https://recipePostUserImage.com",
+                                        "likedByCurrentUser": false,
+                                        "scrappedByCurrentUser": false,
+                                        "id": 3,
+                                        "authorId": 1,
                                         "title": "방울토마토 소박이",
-                                        "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00031_1.png",
+                                        "imageUrl": "http://foodsafetykorea/food.jpg",
                                         "description": "기타",
                                         "categorySlowAging": "염증감소",
-                                        "categoryType": "한식",
+                                        "categoryType": "디저트",
                                         "difficulty": "쉬움",
                                         "timeHours": 0,
                                         "timeMinutes": 45,
@@ -134,20 +130,30 @@ public interface RecipeApi {
                                           5,
                                           1101
                                         ],
-                                        "ingredients": {
-                                          "통깨": "약간",
-                                          "방울토마토": "150g(5개)",
-                                          "부추": "10g(5줄기)",
-                                          "물": "2ml(1/3작은술)"
-                                        },
-                                        "seasoning": {
-                                          "고춧가루": "4g(1작은술)",
-                                          "멸치액젓": "3g(2/3작은술)",
-                                          "다진 마늘": "2.5g(1/2쪽)",
-                                          "매실액": "2g(1/3작은술)",
-                                          "양파": "10g(3×1cm)",
-                                          "설탕": "2g(1/3작은술)"
-                                        },
+                                        "ingredients": [
+                                              {
+                                                "name": "방울토마토",
+                                                "value": "5",
+                                                "unit": "개"
+                                              },
+                                              {
+                                                "name": "부추",
+                                                "value": "5",
+                                                "unit": "줄기"
+                                              }
+                                        ],
+                                        "seasonings": [
+                                              {
+                                                "name": "양파",
+                                                "value": "10",
+                                                "unit": "g"
+                                              },
+                                              {
+                                                "name": "고춧가루",
+                                                "value": "1",
+                                                "unit": "작은술"
+                                              }
+                                         ],
                                         "stepDescriptions": [
                                           "물기를 빼고 2cm 정도의 크기로 썰은 부추와 양파를 양념장에 섞어 양념속을 만든다.",
                                           "깨끗이 씻은 방울토마토는 꼭지를 떼고 윗부분에 칼로 십자모양으로 칼집을 낸다.",

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeEventApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/controller/api/RecipeEventApi.java
@@ -18,8 +18,42 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import java.util.List;
+
 @Tag(name = "Recipe Event API", description = "레시피 이벤트 관련 API")
 public interface RecipeEventApi {
+    // 레시피별 댓글 조회
+    @Operation(summary = "레시피별 댓글 조회", description = "레시피별 댓글을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "댓글 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                        {
+                                          "status": 200,
+                                          "code": "200 OK",
+                                          "message": "댓글 조회 성공 ",
+                                          "data": [
+                                              {
+                                                "commentId": 1,
+                                                "recipeId": 1,
+                                                "nickName": "mj",
+                                                "title": "비타민수호자",
+                                                "authorProfileUrl": "http://profile.img",
+                                                "content": "레시피1에 댓글달기",
+                                                "createdAt": "2025-06-30T06:17:39",
+                                                "updatedAt": "2025-06-30T06:17:39"
+                                              }
+                                          ]
+                                        }
+                                    """))),
+            @ApiResponse(responseCode = "500", description = "댓글 조회 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    ResponseEntity<CommonResponse<List<RecipeCommentResponseDTO>>> getCommentsByRecipeId(
+            @PathVariable Long recipeId
+    );
+
     // 댓글 등록하기
     @Operation(summary = "레시피 댓글 등록", description = "레시피에 댓글을 등록합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeDetailResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/dto/response/RecipeDetailResponseDTO.java
@@ -19,10 +19,10 @@ import java.util.stream.Collectors;
 @Setter
 public class RecipeDetailResponseDTO {
     private Long id;
-    private String authorNickname; // 작성자의 닉네임
-    private String authorTitle; // 작성자의 칭호
+    //private String authorNickname; // 작성자의 닉네임
+    //private String authorTitle; // 작성자의 칭호
     private Long authorId; // 작성자의 아이디
-    private String authorProfileUrl; // 레시피 작성자의 프로필이미지
+    //private String authorProfileUrl; // 레시피 작성자의 프로필이미지
     private Boolean authorFollowByCurrentUser; // 현재 사용자가 작성자를 팔로우했는지 여부
     private String title;
     private String imageUrl;
@@ -52,14 +52,14 @@ public class RecipeDetailResponseDTO {
     private List<String> allergies;
 
     // 댓글 리스트
-    private List<RecipeCommentResponseDTO> comments;
+    //private List<RecipeCommentResponseDTO> comments;
 
-    public RecipeDetailResponseDTO(Recipe recipe, Boolean authorFollowByCurrentUser, List<RecipeCommentResponseDTO> comments, Boolean likedByCurrentUser, Boolean scrappedByCurrentUser) {
+    public RecipeDetailResponseDTO(Recipe recipe, Boolean authorFollowByCurrentUser, /*List<RecipeCommentResponseDTO> comments,*/ Boolean likedByCurrentUser, Boolean scrappedByCurrentUser) {
         this.id = recipe.getId();
-        this.authorNickname = recipe.getMember().getNickname();
-        this.authorTitle = recipe.getMember().getTitle();
+        //this.authorNickname = recipe.getMember().getNickname();
+        //this.authorTitle = recipe.getMember().getTitle();
         this.authorId = recipe.getMember().getId();
-        this.authorProfileUrl = recipe.getMember().getProfileUrl();
+        //this.authorProfileUrl = recipe.getMember().getProfileUrl();
         this.authorFollowByCurrentUser = authorFollowByCurrentUser;
         this.title = recipe.getTitle();
         this.imageUrl = recipe.getImageUrl();
@@ -121,7 +121,7 @@ public class RecipeDetailResponseDTO {
         if (Boolean.TRUE.equals(recipe.getAllergy_홍합())) allergies.add("홍합");
         if (Boolean.TRUE.equals(recipe.getAllergy_잣())) allergies.add("잣");
 
-        this.comments = comments;
+        // this.comments = comments;
     }
 
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeEventService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeEventService.java
@@ -15,6 +15,9 @@ import jakarta.transaction.Transactional;
 import lombok.*;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class RecipeEventService {
@@ -22,6 +25,14 @@ public class RecipeEventService {
     private final RecipeRepository recipeRepository;
     private final RecipeEventRepository recipeEventRepository;
     private final S3Service s3Service;
+
+    // 레시피별 댓글 조회
+    public List<RecipeCommentResponseDTO> getCommentsByRecipeId(Long recipeId) {
+        return recipeEventRepository.findAllByRecipeId(recipeId)
+                .stream()
+                .map(RecipeCommentResponseDTO::new)
+                .collect(Collectors.toList());
+    }
 
     // 댓글 등록하기
     public RecipeCommentResponseDTO addComment(

--- a/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/recipe/service/RecipeService.java
@@ -48,7 +48,7 @@ public class RecipeService {
 
     // 레시피 등록하기
     @Transactional
-    public RecipeResponseDTO createRecipe(
+    public RecipeDetailResponseDTO createRecipe(
             RecipeRequestDTO dto,
             MultipartFile image,
             List<MultipartFile> recipeStepImages,
@@ -101,7 +101,12 @@ public class RecipeService {
         // 챌린지 달성을 위한 이벤트 발행
         eventPublisher.publishEvent(new RecipeEvent(member.getId(), recipe.getId(), LocalDateTime.now()));
 
-        return new RecipeResponseDTO(recipe);
+        // 작성자 팔로우 여부 확인
+        boolean authorFollowByCurrentUser = followRepository.existsByFollowerAndFollowing(member, member);
+        // 좋아요 및 스크랩 여부 확인
+        boolean likedByCurrentUser = recipeEventRepository.existsByRecipeIdAndMemberIdAndLikeFlagTrue(recipe.getId(), member.getId());
+        boolean scrappedByCurrentUser = recipeEventRepository.existsByRecipeIdAndMemberIdAndScrapFlagTrue(recipe.getId(), member.getId());
+        return new RecipeDetailResponseDTO(recipe, authorFollowByCurrentUser, likedByCurrentUser, scrappedByCurrentUser);
     }
 
     // 레시피 조회
@@ -122,18 +127,12 @@ public class RecipeService {
         // 레시피 작성자
         Member authorRecipe = recipe.getMember();
 
-        // 댓글 가져오기
-        List<RecipeCommentResponseDTO> comments = recipeEventRepository.findAllByRecipeId(recipeId)
-                .stream()
-                .map(RecipeCommentResponseDTO::new)
-                .collect(Collectors.toList());
-
         // 작성자 팔로우 여부 확인
         boolean authorFollowByCurrentUser = followRepository.existsByFollowerAndFollowing(member, authorRecipe);
         // 좋아요 및 스크랩 여부 확인
         boolean likedByCurrentUser = recipeEventRepository.existsByRecipeIdAndMemberIdAndLikeFlagTrue(recipeId, member.getId());
         boolean scrappedByCurrentUser = recipeEventRepository.existsByRecipeIdAndMemberIdAndScrapFlagTrue(recipeId, member.getId());
-        return new RecipeDetailResponseDTO(recipe, authorFollowByCurrentUser, comments, likedByCurrentUser, scrappedByCurrentUser);
+        return new RecipeDetailResponseDTO(recipe, authorFollowByCurrentUser, likedByCurrentUser, scrappedByCurrentUser);
     }
 
     // 레시피 목록(홈) 조회


### PR DESCRIPTION
## 📌 Issue Number
- https://github.com/SWU-Elixir/Backend/issues/3

## 🪐 작업 내용
- 레시피 등록 시 반환값을 RecipeDetailResponseDTO로 변경
- RecipeDetailResponseDTO 내부 댓글 리스트 필드를 제거
- 레시피 별 댓글을 조회하는 API(GET /recipe/{recipeId}/comment) 분리 구현

## ✅ PR 상세 내용
- 댓글을 RecipeDetailResponseDTO에서 분리함으로써 응답 객체의 책임을 분리

## 📚 Reference
- X