### PR TITLE
feat: 서버, DB 타임존 KST로 설정

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/ElixirApplication.java
+++ b/src/main/java/BE_Elixir/Elixir/ElixirApplication.java
@@ -3,10 +3,16 @@ package BE_Elixir.Elixir;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class ElixirApplication {
 
 	public static void main(String[] args) {
+		// KST로 타임존 설정
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+
 		SpringApplication.run(ElixirApplication.class, args);
 	}
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -15,6 +15,7 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.type.descriptor.sql=trace
 spring.jpa.properties.hibernate.use_sql_comments=true
+#spring.jpa.properties.hibernate.jdbc.time_zone=KST
 
 # sql (always)
 spring.jpa.defer-datasource-initialization=false


### PR DESCRIPTION
## 📌 Issue Number
- closed #134 

## 🪐 작업 내용
- 서버, DB 타임존 KST로 설정

## ✅ PR 상세 내용
- JPA DB 서버 타임존 설정
- 스프링부트 서버 타임존 설정


## 📚 Reference
- [[스프링 부트, MySQL] 타임존(timeZone) 설정하기- 서버 별 시간 불일치 해결 방법](https://jh-industry.tistory.com/174)