### PR TITLE
fix: 이번 달 챌린지가 없을 경우 로그인이 실패되는 문제 해결

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package BE_Elixir.Elixir.domain.auth.service;
 import BE_Elixir.Elixir.domain.auth.dto.AccessTokenDTO;
 import BE_Elixir.Elixir.domain.auth.dto.response.TokenResponseDTO;
 import BE_Elixir.Elixir.domain.auth.dto.request.LoginRequestDTO;
+import BE_Elixir.Elixir.domain.challenge.event.events.LoginSuccessEvent;
 import BE_Elixir.Elixir.domain.challenge.service.ChallengeAchievementService;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
 import BE_Elixir.Elixir.domain.member.service.MemberDetailsService;
@@ -13,6 +14,7 @@ import BE_Elixir.Elixir.global.security.JwtProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -31,7 +33,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final RedisAuthService redisAuthService;
     private final MemberDetailsService memberDetailsService;
-    private final ChallengeAchievementService challengeAchievementService;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 로그인 (jwt 발급 및 Redis 저장)
     public TokenResponseDTO signIn(LoginRequestDTO request) {
@@ -53,10 +55,8 @@ public class AuthService {
             redisAuthService.saveRefreshToken(email, refreshToken);
             log.info("Refresh Token Redis에 저장: email={}, token={}", email, refreshToken);
 
-            String memberEmail = request.getEmail();
-
-            // 자동 참여 메서드 호출
-            challengeAchievementService.challengeParticipation(memberEmail);
+            // 로그인 성공 이벤트 발행
+            eventPublisher.publishEvent(new LoginSuccessEvent(request.getEmail()));
 
             return tokenResponse;
         } catch (BadCredentialsException e) {

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/event/events/LoginSuccessEvent.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/event/events/LoginSuccessEvent.java
@@ -1,0 +1,17 @@
+package BE_Elixir.Elixir.domain.challenge.event.events;
+
+import lombok.Getter;
+
+@Getter
+// 로그인할 때 발생하는 이벤트
+public class LoginSuccessEvent {
+    private final String email;
+
+    public LoginSuccessEvent(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/event/listener/LoginAutoJoinListener.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/event/listener/LoginAutoJoinListener.java
@@ -1,0 +1,25 @@
+package BE_Elixir.Elixir.domain.challenge.event.listener;
+
+
+import BE_Elixir.Elixir.domain.challenge.event.events.LoginSuccessEvent;
+import BE_Elixir.Elixir.domain.challenge.service.ChallengeAchievementService;
+import BE_Elixir.Elixir.global.exception.CustomException;
+import BE_Elixir.Elixir.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LoginAutoJoinListener {
+    private final ChallengeAchievementService challengeAchievementService;
+
+    @EventListener
+    public void onLogin(LoginSuccessEvent event) {
+        challengeAchievementService.challengeParticipation(event.getEmail());
+        log.info("자동 챌린지 참여 완료: {}", event.getEmail());
+    }
+
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/challenge/service/ChallengeAchievementService.java
@@ -12,6 +12,7 @@ import BE_Elixir.Elixir.global.exception.CustomException;
 import BE_Elixir.Elixir.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -19,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ChallengeAchievementService {
 
@@ -135,9 +137,14 @@ public class ChallengeAchievementService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND))
                 .getId();
 
-        Challenge challenge = challengeRepository.findByYearAndMonth(year, month)
-                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_NOT_FOUND));
+        Optional<Challenge> optionalChallenge = challengeRepository.findByYearAndMonth(year, month);
 
+        if (optionalChallenge.isEmpty()) {
+            log.info("이번 달 챌린지가 없어 자동 참여를 스킵합니다. memberEmail={}", memberEmail);
+            return;
+        }
+
+        Challenge challenge = optionalChallenge.get();
         ChallengeAchievementId id = new ChallengeAchievementId(memberId, challenge.getId());
 
         boolean exists = challengeAchievementRepository.existsById(id);

--- a/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
+++ b/src/main/java/BE_Elixir/Elixir/global/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
 
     // 챌린지
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "챌린지를 찾을 수 없습니다."),
+    CHALLENGE_THIS_MONTH_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "이번 달 챌린지가 없습니다."),
     CHALLENGE_ACHIEVEMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "챌린지 기록이 없습니다."),
 
     // 설문조사


### PR DESCRIPTION
## 📌 Issue Number
- #22 

## 🪐 작업 내용
- 로그인 성공 시 챌린지 자동 참여 이벤트 발행 (`LoginSuccessEvent`)
- `LoginAutoJoinListener` 분리 및 리스너 기반 참여 처리
- 챌린지가 없다는 예외 발생 시 로깅 후 스킵 처리
- `challengeParticipation()` 내 존재 여부 체크 및 예외 처리

## ✅ PR 
- 기존 AuthService 내부에서 직접 호출하던 자동참여 로직을 이벤트 기반으로 리팩토링하여, 로그인 흐름의 의존성을 분리
- 챌린지가 없을 경우 로그인은 정상적으로 진행되며, 리스너 내부에서 관련 예외를 캐치하고 무시
- 소셜 로그인에서도 동일한 방식으로 이벤트만 발행하면 자동 참여 기능이 동작할 수 있도록 설계

## 📚 Reference
- X