### PR TITLE
feat: 사용자 업적 전체/달성한 최신 업적 3개 조회 API 구현

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/achievement/repository/MemberAchievementRepository.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/achievement/repository/MemberAchievementRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 @Repository
 public interface MemberAchievementRepository extends JpaRepository<MemberAchievement, Long> {
     List<MemberAchievement> findAllByMember(Member member);
+
+    List<MemberAchievement> findTop3ByMemberAndCompletedTrueOrderByCompletedAtDescUpdatedAtDesc(Member member);
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
@@ -262,4 +262,16 @@ public class MyPageController implements MyPageApi {
                 "다른 사용자의 모든 업적 조회 성공", achievements));
     }
 
+    // 다른 사용자가 달성한 최신 업적 3개 조회
+    @GetMapping("/{memberId}/achievement/top3")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3StatsAchievementsByMemberId(
+            @PathVariable Long memberId
+    ) {
+        List<MemberAchievementResponseDTO> top3 = myPageService.getTop3StatsAchievements(memberId);
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "다른 사용자가 달성한 최신 업적 3개 조회 성공", top3));
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
@@ -167,12 +167,12 @@ public class MyPageController implements MyPageApi {
 
     // 로그인한 사용자의 모든 챌린지 업적 정보 조회
     @GetMapping("/achievement")
-    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         Long memberId = memberDetails.getId();
 
-        List<MemberAchievementResponseDTO> achievements = myPageService.getAllAchievements(memberId);
+        List<MemberChallengeResponseDTO> achievements = myPageService.getAllAchievements(memberId);
 
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
@@ -181,12 +181,12 @@ public class MyPageController implements MyPageApi {
 
     // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
     @GetMapping("/achievement/top3")
-    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3Achievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         Long memberId = memberDetails.getId();
 
-        List<MemberAchievementResponseDTO> top3Achievements = myPageService.getTop3Achievements(memberId);
+        List<MemberChallengeResponseDTO> top3Achievements = myPageService.getTop3Achievements(memberId);
 
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
@@ -206,10 +206,10 @@ public class MyPageController implements MyPageApi {
 
     // 다른 사용자의 모든 챌린지 업적 정보 조회하기
     @GetMapping("/{memberId}/achievements")
-    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievementsByMemberId(
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievementsByMemberId(
             @PathVariable Long memberId
     ) {
-        List<MemberAchievementResponseDTO> achievements = myPageService.getAllAchievementsByMemberId(memberId);
+        List<MemberChallengeResponseDTO> achievements = myPageService.getAllAchievementsByMemberId(memberId);
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
                 "다른 사용자의 모든 업적 조회 성공", achievements));
@@ -217,12 +217,25 @@ public class MyPageController implements MyPageApi {
 
     // 다른 사용자의 최근 3개 업적 조회하기
     @GetMapping("/{memberId}/achievements/top3")
-    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3AchievementsByMemberId(
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3AchievementsByMemberId(
             @PathVariable Long memberId
     ) {
-        List<MemberAchievementResponseDTO> achievements = myPageService.getTop3AchievementsByMemberId(memberId);
+        List<MemberChallengeResponseDTO> achievements = myPageService.getTop3AchievementsByMemberId(memberId);
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
                 "다른 사용자의 최근 업적 3개 조회 성공", achievements));
     }
+
+    // 로그인한 사용자의 모든 업적 조회
+    @GetMapping("/stats-achievements")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllMyStatsAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        List<MemberAchievementResponseDTO> achievements = myPageService.getAllMyStatsAchievements(memberDetails.getId());
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "로그인한 사용자의 모든 업적 조회 성공", achievements));
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
@@ -165,8 +165,8 @@ public class MyPageController implements MyPageApi {
                 "내가 스크랩한 레시피 조회 성공", scrappedRecipes));
     }
 
-    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
-    @GetMapping("/achievement")
+    // 로그인한 사용자의 모든 챌린지 업적 조회
+    @GetMapping("/challenge")
     public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
@@ -179,8 +179,8 @@ public class MyPageController implements MyPageApi {
                 "모든 챌린지 업적 조회 성공", achievements));
     }
 
-    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
-    @GetMapping("/achievement/top3")
+    // 로그인한 사용자의 달성한 최신 챌린지 업적 3개 조회하기
+    @GetMapping("/challenge/top3")
     public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3Achievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
@@ -204,8 +204,8 @@ public class MyPageController implements MyPageApi {
 
     }
 
-    // 다른 사용자의 모든 챌린지 업적 정보 조회하기
-    @GetMapping("/{memberId}/achievements")
+    // 다른 사용자의 모든 챌린지 업적 조회하기
+    @GetMapping("/{memberId}/challenge")
     public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievementsByMemberId(
             @PathVariable Long memberId
     ) {
@@ -215,8 +215,8 @@ public class MyPageController implements MyPageApi {
                 "다른 사용자의 모든 업적 조회 성공", achievements));
     }
 
-    // 다른 사용자의 최근 3개 업적 조회하기
-    @GetMapping("/{memberId}/achievements/top3")
+    // 다른 사용자의 달성한 최신 챌린지 업적 3개 조회하기
+    @GetMapping("/{memberId}/challenge/top3")
     public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3AchievementsByMemberId(
             @PathVariable Long memberId
     ) {
@@ -227,7 +227,7 @@ public class MyPageController implements MyPageApi {
     }
 
     // 로그인한 사용자의 모든 업적 조회
-    @GetMapping("/stats-achievements")
+    @GetMapping("/achievement")
     public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllMyStatsAchievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
@@ -176,7 +176,7 @@ public class MyPageController implements MyPageApi {
 
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                "모든 챌린지 업적 조회 성공", achievements));
+                "로그인한 사용자의 모든 챌린지 업적 조회 성공", achievements));
     }
 
     // 로그인한 사용자의 달성한 최신 챌린지 업적 3개 조회하기
@@ -190,7 +190,7 @@ public class MyPageController implements MyPageApi {
 
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                "최근 업적 3개 조회 성공", top3Achievements));
+                "로그인한 사용자가 달성한 최신 챌린지 업적 3개 조회 성공", top3Achievements));
     }
 
     // 다른 사용자가 업로드한 모든 레시피 조회하기
@@ -212,7 +212,7 @@ public class MyPageController implements MyPageApi {
         List<MemberChallengeResponseDTO> achievements = myPageService.getAllAchievementsByMemberId(memberId);
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                "다른 사용자의 모든 업적 조회 성공", achievements));
+                "다른 사용자의 모든 챌린지 업적 조회 성공", achievements));
     }
 
     // 다른 사용자의 달성한 최신 챌린지 업적 3개 조회하기
@@ -223,7 +223,7 @@ public class MyPageController implements MyPageApi {
         List<MemberChallengeResponseDTO> achievements = myPageService.getTop3AchievementsByMemberId(memberId);
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                "다른 사용자의 최근 업적 3개 조회 성공", achievements));
+                "다른 사용자가 달성한 최신 챌린지 업적 3개 조회 성공", achievements));
     }
 
     // 로그인한 사용자의 모든 업적 조회
@@ -238,4 +238,15 @@ public class MyPageController implements MyPageApi {
                 "로그인한 사용자의 모든 업적 조회 성공", achievements));
     }
 
+    // 로그인한 사용자가 달성한 최신 업적 3개 조회
+    @GetMapping("/achievement/top3")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getMyTop3Achievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        List<MemberAchievementResponseDTO> top3 = myPageService.getTop3StatsAchievements(memberDetails.getId());
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "로그인한 사용자가 달성한 최신 업적 3개 조회 성공", top3));
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
@@ -249,4 +249,17 @@ public class MyPageController implements MyPageApi {
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
                 "로그인한 사용자가 달성한 최신 업적 3개 조회 성공", top3));
     }
+
+    // 다른 사용자의 모든 업적 조회
+    @GetMapping("/{memberId}/achievement")
+    public ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllStatsAchievementsByMemberId(
+            @PathVariable Long memberId
+    ) {
+        List<MemberAchievementResponseDTO> achievements = myPageService.getAllMyStatsAchievements(memberId);
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "다른 사용자의 모든 업적 조회 성공", achievements));
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
@@ -471,7 +471,7 @@ public interface MyPageApi {
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "다른 사용자의 모든 업적 조회 성공",
+                                      "message": "다른 사용자의 모든 챌린지 업적 조회 성공",
                                       "data": [
                                         {
                                           "year": 2025,
@@ -552,11 +552,64 @@ public interface MyPageApi {
                                       "code": "200 OK",
                                       "message": "로그인한 사용자의 모든 업적 조회 성공",
                                       "data": [
-                                        ]
+                                          {
+                                            "achievementName": "꾸준함 입문자",
+                                            "achievementImageUrl": "https://s3elixir.s3.ap-northeast-2.amazonaws.com/achievement/gray/TotalLogin1_g.png",
+                                            "completed": false,
+                                            "level": 1,
+                                            "type": "TOTAL_LOGIN_DAYS",
+                                            "code": "TOTAL_LOGIN_DAYS_LV1"
+                                          },
+                                          {
+                                            "achievementName": "생활 루틴러",
+                                            "achievementImageUrl": "https://s3elixir.s3.ap-northeast-2.amazonaws.com/achievement/gray/TotalLogin2_g.png",
+                                            "completed": false,
+                                            "level": 2,
+                                            "type": "TOTAL_LOGIN_DAYS",
+                                            "code": "TOTAL_LOGIN_DAYS_LV2"
+                                          },
+                                          {
+                                            "achievementName": "엘릭서 수호자",
+                                            "achievementImageUrl": "https://s3elixir.s3.ap-northeast-2.amazonaws.com/achievement/gray/TotalLogin3_g.png",
+                                            "completed": false,
+                                            "level": 3,
+                                            "type": "TOTAL_LOGIN_DAYS",
+                                            "code": "TOTAL_LOGIN_DAYS_LV3"
+                                         },
+                                         {}...
+                                       ]
                                     }
                                     """)))
     })
     ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllMyStatsAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // 로그인한 사용자가 달성한 최신 업적 3개 조회
+    @Operation(summary = "로그인한 사용자가 달성한 최신 업적 3개 조회하기", description = "로그인한 사용자가 달성한 최신 업적 3개를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자가 달성한 최신 업적 3개 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인한 사용자가 달성한 최신 업적 3개 조회 성공",
+                                      "data": [
+                                        {
+                                          "achievementName": "요리 탐험가",
+                                          "achievementImageUrl": "https://s3elixir.s3.ap-northeast-2.amazonaws.com/achievement/color/Scrap1.png",
+                                          "completed": true,
+                                          "level": 1,
+                                          "type": "TOTAL_SCRAPS",
+                                          "code": "TOTAL_SCRAPS_LV1"
+                                        }
+                                      ]
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getMyTop3Achievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -380,7 +381,7 @@ public interface MyPageApi {
                                      }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievements(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
@@ -421,7 +422,7 @@ public interface MyPageApi {
                                     }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3Achievements(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3Achievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
@@ -493,7 +494,7 @@ public interface MyPageApi {
                                     }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllAchievementsByMemberId(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievementsByMemberId(
             @PathVariable Long memberId
     );
 
@@ -534,7 +535,28 @@ public interface MyPageApi {
                                     }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3AchievementsByMemberId(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3AchievementsByMemberId(
             @PathVariable Long memberId
+    );
+
+
+    // 로그인한 사용자의 모든 업적 조회
+    @Operation(summary = "로그인한 사용자의 모든 업적 조회하기", description = "로그인한 사용자의 모든 업적 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 모든 업적 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "로그인한 사용자의 모든 업적 조회 성공",
+                                      "data": [
+                                        ]
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllMyStatsAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
     );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
@@ -330,11 +330,11 @@ public interface MyPageApi {
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
-    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
-    @Operation(summary = "로그인한 사용자의 모든 챌린지 업적 정보 조회하기", description = "로그인한 사용자의 모든 챌린지 업적 정보를 조회합니다.",
+    // 로그인한 사용자의 모든 챌린지 업적 조회
+    @Operation(summary = "로그인한 사용자의 모든 챌린지 업적 조회하기", description = "로그인한 사용자의 모든 챌린지 업적을 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 모든 챌린지 업적 정보 조회 성공",
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 모든 챌린지 업적 조회 성공",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
@@ -385,17 +385,17 @@ public interface MyPageApi {
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
-    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
-    @Operation(summary = "로그인한 사용자의 달성한 업적 최신 3개 조회하기", description = "로그인한 사용자의 달성한 업적 최신 3개를 조회합니다.",
+    // 로그인한 사용자가 달성한 최신 챌린지 업적 3개 조회하기
+    @Operation(summary = "로그인한 사용자가 달성한 최신 챌린지 업적 3개 조회하기", description = "로그인한 사용자가 달성한 최신 챌린지 업적 3개를 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인한 사용자의 달성한 업적 최신 3개 조회 성공",
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자가 달성한 최신 챌린지 업적 3개 조회 성공",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "최근 업적 3개 조회 성공",
+                                      "message": "로그인한 사용자가 달성한 최신 챌린지 업적 3개 성공",
                                       "data": [
                                         {
                                           "year": 2025,
@@ -462,10 +462,10 @@ public interface MyPageApi {
     );
 
     // 다른 사용자의 모든 챌린지 업적 정보 조회하기
-    @Operation(summary = "다른 사용자의 모든 챌린지 업적 정보 조회하기", description = "다른 사용자의 모든 챌린지 업적 정보 조회합니다.",
+    @Operation(summary = "다른 사용자의 모든 챌린지 업적 조회하기", description = "다른 사용자의 모든 챌린지 업적 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "다른 사용자의 모든 챌린지 업적 정보 조회 성공",
+            @ApiResponse(responseCode = "200", description = "다른 사용자의 모든 챌린지 업적 조회 성공",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
@@ -498,17 +498,17 @@ public interface MyPageApi {
             @PathVariable Long memberId
     );
 
-    // 다른 사용자의 최근 3개 업적 조회하기
-    @Operation(summary = "다른 사용자의 최근 3개 업적 조회하기", description = "다른 사용자의 최근 3개 업적 조회합니다.",
+    // 다른 사용자가 달성한 최신 챌린지 업적 3개 조회하기
+    @Operation(summary = "다른 사용자가 달성한 최신 챌린지 업적 3개 조회하기", description = "다른 사용자가 달성한 최신 챌린지 업적 3개 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "다른 사용자의 최근 3개 업적 조회 성공",
+            @ApiResponse(responseCode = "200", description = "다른 사용자가 달성한 최신 챌린지 업적 3개 조회 성공",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class),
                             examples = @ExampleObject(value = """
                                     {
                                       "status": 200,
                                       "code": "200 OK",
-                                      "message": "다른 사용자의 최근 업적 3개 조회 성공",
+                                      "message": "다른 사용자가 달성한 최신 챌린지 업적 3개 조회 성공",
                                       "data": [
                                         {
                                           "year": 2025,
@@ -541,7 +541,7 @@ public interface MyPageApi {
 
 
     // 로그인한 사용자의 모든 업적 조회
-    @Operation(summary = "로그인한 사용자의 모든 업적 조회하기", description = "로그인한 사용자의 모든 업적 조회합니다.",
+    @Operation(summary = "로그인한 사용자의 모든 업적 조회하기", description = "로그인한 사용자의 모든 업적을 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인한 사용자의 모든 업적 조회 성공",

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
@@ -568,14 +568,6 @@ public interface MyPageApi {
                                             "type": "TOTAL_LOGIN_DAYS",
                                             "code": "TOTAL_LOGIN_DAYS_LV2"
                                           },
-                                          {
-                                            "achievementName": "엘릭서 수호자",
-                                            "achievementImageUrl": "https://s3elixir.s3.ap-northeast-2.amazonaws.com/achievement/gray/TotalLogin3_g.png",
-                                            "completed": false,
-                                            "level": 3,
-                                            "type": "TOTAL_LOGIN_DAYS",
-                                            "code": "TOTAL_LOGIN_DAYS_LV3"
-                                         },
                                          {}...
                                        ]
                                     }
@@ -611,5 +603,34 @@ public interface MyPageApi {
     })
     ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getMyTop3Achievements(
             @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+    // 다른 사용자의 모든 업적 조회
+    @Operation(summary = "다른 사용자의 모든 업적 조회하기", description = "다른 사용자의 모든 업적을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 사용자의 모든 업적 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "다른 사용자의 모든 업적 조회 성공",
+                                      "data": [
+                                          {
+                                            "achievementName": "꾸준함 입문자",
+                                            "achievementImageUrl": "https://s3elixir.s3.ap-northeast-2.amazonaws.com/achievement/gray/TotalLogin1_g.png",
+                                            "completed": false,
+                                            "level": 1,
+                                            "type": "TOTAL_LOGIN_DAYS",
+                                            "code": "TOTAL_LOGIN_DAYS_LV1"
+                                          },
+                                          {}...
+                                       ]
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllStatsAchievementsByMemberId(
+            @PathVariable Long memberId
     );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
@@ -633,4 +633,33 @@ public interface MyPageApi {
     ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getAllStatsAchievementsByMemberId(
             @PathVariable Long memberId
     );
+
+
+    // 다른 사용자가 달성한 최신 업적 3개 조회
+    @Operation(summary = "다른 사용자가 달성한 최신 업적 3개 조회하기", description = "다른 사용자가 달성한 최신 업적 3개를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 사용자가 달성한 최신 업적 3개 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "다른 사용자가 달성한 최신 업적 3개 조회 성공",
+                                      "data": [
+                                        {
+                                          "achievementName": "요리 탐험가",
+                                          "achievementImageUrl": "https://s3elixir.s3.ap-northeast-2.amazonaws.com/achievement/color/Scrap1.png",
+                                          "completed": true,
+                                          "level": 1,
+                                          "type": "TOTAL_SCRAPS",
+                                          "code": "TOTAL_SCRAPS_LV1"
+                                        }
+                                      ]
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3StatsAchievementsByMemberId(
+            @PathVariable Long memberId
+    );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberAchievementResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberAchievementResponseDTO.java
@@ -1,15 +1,30 @@
 package BE_Elixir.Elixir.domain.member.dto.response;
 
-
+import BE_Elixir.Elixir.domain.achievement.entity.MemberAchievement;
+import BE_Elixir.Elixir.global.enums.AchievementType;
 import lombok.*;
 
 @Getter
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
 public class MemberAchievementResponseDTO {
-    private int year;          // 챌린지 연도
-    private int month;         // 챌린지 월
-    private String achievementName; // 업적 명
-    private String achievementImageUrl; // 업적 이미지
-    private boolean challengeCompleted; // 챌린지 최종 달성 여부
+    private String achievementName;
+    private String achievementImageUrl;
+    private boolean completed;
+    private int level;
+    private AchievementType type;
+    private String code;
+
+    public static MemberAchievementResponseDTO from(MemberAchievement ma) {
+        boolean isCompleted = ma.isCompleted();
+        return new MemberAchievementResponseDTO(
+                ma.getAchievement().getAchievementName(),
+                isCompleted ? ma.getAchievement().getAchievementImageUrl()
+                        : ma.getAchievement().getGrayAchievementImageUrl(),
+                isCompleted,
+                ma.getAchievement().getLevel(),
+                ma.getAchievement().getType(),
+                ma.getAchievement().getCode()
+        );
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberAchievementResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberAchievementResponseDTO.java
@@ -1,5 +1,6 @@
 package BE_Elixir.Elixir.domain.member.dto.response;
 
+import BE_Elixir.Elixir.domain.achievement.entity.Achievement;
 import BE_Elixir.Elixir.domain.achievement.entity.MemberAchievement;
 import BE_Elixir.Elixir.global.enums.AchievementType;
 import lombok.*;
@@ -27,4 +28,20 @@ public class MemberAchievementResponseDTO {
                 ma.getAchievement().getCode()
         );
     }
+
+    public static MemberAchievementResponseDTO from(Achievement achievement, MemberAchievement ma) {
+        String imageUrl = ma.isCompleted()
+                ? achievement.getAchievementImageUrl()
+                : achievement.getGrayAchievementImageUrl();
+
+        return MemberAchievementResponseDTO.builder()
+                .achievementName(achievement.getAchievementName())
+                .achievementImageUrl(imageUrl)
+                .completed(ma.isCompleted())
+                .level(achievement.getLevel())
+                .type(achievement.getType())
+                .code(achievement.getCode())
+                .build();
+    }
+
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberChallengeResponseDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberChallengeResponseDTO.java
@@ -1,0 +1,16 @@
+package BE_Elixir.Elixir.domain.member.dto.response;
+
+
+import BE_Elixir.Elixir.domain.achievement.entity.MemberAchievement;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberChallengeResponseDTO {
+    private int year;          // 챌린지 연도
+    private int month;         // 챌린지 월
+    private String achievementName; // 업적 명
+    private String achievementImageUrl; // 업적 이미지
+    private boolean challengeCompleted; // 챌린지 최종 달성 여부
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
@@ -1,6 +1,8 @@
 package BE_Elixir.Elixir.domain.member.service;
 
+import BE_Elixir.Elixir.domain.achievement.entity.Achievement;
 import BE_Elixir.Elixir.domain.achievement.entity.MemberAchievement;
+import BE_Elixir.Elixir.domain.achievement.repository.AchievementRepository;
 import BE_Elixir.Elixir.domain.achievement.repository.MemberAchievementRepository;
 import BE_Elixir.Elixir.domain.challenge.entity.Challenge;
 import BE_Elixir.Elixir.domain.challenge.entity.ChallengeAchievement;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +47,7 @@ public class MyPageService {
     private final RecipeEventRepository recipeEventRepository;
     private final S3Service s3Service;
     private final MemberAchievementRepository memberAchievementRepository;
+    private final AchievementRepository achievementRepository;
 
 
     // 회원 정보 조회
@@ -399,19 +403,42 @@ public class MyPageService {
                 .collect(Collectors.toList());
     }
 
-    // 로그인한 사용자의 모든 업적 조회
+    // 사용자의 모든 업적 조회
+    @Transactional
     public List<MemberAchievementResponseDTO> getAllMyStatsAchievements(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        List<MemberAchievement> achievements = memberAchievementRepository.findAllByMember(member);
+        List<Achievement> allAchievements = achievementRepository.findAll(); // 총 18개
+        List<MemberAchievement> existingAchievements = memberAchievementRepository.findAllByMember(member);
 
-        return achievements.stream()
-                .map(MemberAchievementResponseDTO::from)
-                .toList();
+        // 이미 존재하는 업적 정리
+        Map<Long, MemberAchievement> achievementMap = existingAchievements.stream()
+                .collect(Collectors.toMap(ma -> ma.getAchievement().getId(), ma -> ma));
+
+        List<MemberAchievementResponseDTO> result = new ArrayList<>();
+
+        for (Achievement achievement : allAchievements) {
+            MemberAchievement ma = achievementMap.get(achievement.getId());
+
+            // 누락된 업적 자동 생성
+            if (ma == null) {
+                ma = new MemberAchievement();
+                ma.setMember(member);
+                ma.setAchievement(achievement);
+                ma.setCurrentProgress(0);
+                ma.setCompleted(false);
+                memberAchievementRepository.save(ma);
+            }
+
+            result.add(MemberAchievementResponseDTO.from(achievement, ma));
+        }
+
+        return result;
     }
 
-    // 로그인한 사용자가 달성한 최신 업적 3개 조회
+
+    // 사용자가 달성한 최신 업적 3개 조회
     public List<MemberAchievementResponseDTO> getTop3StatsAchievements(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
@@ -1,15 +1,14 @@
 package BE_Elixir.Elixir.domain.member.service;
 
+import BE_Elixir.Elixir.domain.achievement.entity.MemberAchievement;
+import BE_Elixir.Elixir.domain.achievement.repository.MemberAchievementRepository;
 import BE_Elixir.Elixir.domain.challenge.entity.Challenge;
 import BE_Elixir.Elixir.domain.challenge.entity.ChallengeAchievement;
 import BE_Elixir.Elixir.domain.challenge.repository.ChallengeAchievementRepository;
 import BE_Elixir.Elixir.domain.challenge.repository.ChallengeRepository;
 import BE_Elixir.Elixir.domain.member.dto.request.MemberProfileRequestDTO;
 import BE_Elixir.Elixir.domain.member.dto.request.SurveyRequestDTO;
-import BE_Elixir.Elixir.domain.member.dto.response.MemberAchievementResponseDTO;
-import BE_Elixir.Elixir.domain.member.dto.response.MemberProfileResponseDTO;
-import BE_Elixir.Elixir.domain.member.dto.response.MemberResponseDTO;
-import BE_Elixir.Elixir.domain.member.dto.response.SurveyResponseDTO;
+import BE_Elixir.Elixir.domain.member.dto.response.*;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.repository.MemberRepository;
 import BE_Elixir.Elixir.domain.recipe.dto.response.RecipeImageResponseDTO;
@@ -44,6 +43,8 @@ public class MyPageService {
     private final ChallengeAchievementRepository challengeAchievementRepository;
     private final RecipeEventRepository recipeEventRepository;
     private final S3Service s3Service;
+    private final MemberAchievementRepository memberAchievementRepository;
+
 
     // 회원 정보 조회
     public MemberResponseDTO getMemberInfo(String email) {
@@ -229,7 +230,7 @@ public class MyPageService {
     }
 
     // 로그인한 사용자의 모든 챌린지 업적 정보 조회
-    public List<MemberAchievementResponseDTO> getAllAchievements(Long memberId) {
+    public List<MemberChallengeResponseDTO> getAllAchievements(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -256,7 +257,7 @@ public class MyPageService {
                             challenge.getAchievementImageUrl() :
                             challenge.getGrayAchievementImageUrl();
 
-                    return new MemberAchievementResponseDTO(
+                    return new MemberChallengeResponseDTO(
                             challenge.getYear(),
                             challenge.getMonth(),
                             challenge.getAchievementName(),
@@ -268,7 +269,7 @@ public class MyPageService {
     }
 
     // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
-    public List<MemberAchievementResponseDTO> getTop3Achievements(Long memberId) {
+    public List<MemberChallengeResponseDTO> getTop3Achievements(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -288,7 +289,7 @@ public class MyPageService {
                 .collect(Collectors.toMap(Challenge::getId, c -> c));
 
         // 업적 필터 + 정렬 + DTO 변환
-        List<MemberAchievementResponseDTO> top3Achievements = achievements.stream()
+        List<MemberChallengeResponseDTO> top3Achievements = achievements.stream()
                 .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
                 .sorted((a1, a2) -> {
                     Challenge c1 = challengeMap.get(a1.getChallengeId());
@@ -299,7 +300,7 @@ public class MyPageService {
                 .limit(3)
                 .map(a -> {
                     Challenge challenge = challengeMap.get(a.getChallengeId());
-                    return new MemberAchievementResponseDTO(
+                    return new MemberChallengeResponseDTO(
                             challenge.getYear(),
                             challenge.getMonth(),
                             challenge.getAchievementName(),
@@ -325,7 +326,7 @@ public class MyPageService {
     }
 
     // 다른 사용자의 모든 챌린지 업적 정보 조회하기
-    public List<MemberAchievementResponseDTO> getAllAchievementsByMemberId(Long memberId) {
+    public List<MemberChallengeResponseDTO> getAllAchievementsByMemberId(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -347,7 +348,7 @@ public class MyPageService {
                             ? challenge.getAchievementImageUrl()
                             : challenge.getGrayAchievementImageUrl();
 
-                    return new MemberAchievementResponseDTO(
+                    return new MemberChallengeResponseDTO(
                             challenge.getYear(),
                             challenge.getMonth(),
                             challenge.getAchievementName(),
@@ -358,7 +359,7 @@ public class MyPageService {
     }
 
     // 다른 사용자의 최신 업적 3개 조회
-    public List<MemberAchievementResponseDTO> getTop3AchievementsByMemberId(Long memberId) {
+    public List<MemberChallengeResponseDTO> getTop3AchievementsByMemberId(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -387,7 +388,7 @@ public class MyPageService {
                 .limit(3)
                 .map(a -> {
                     Challenge challenge = challengeMap.get(a.getChallengeId());
-                    return new MemberAchievementResponseDTO(
+                    return new MemberChallengeResponseDTO(
                             challenge.getYear(),
                             challenge.getMonth(),
                             challenge.getAchievementName(),
@@ -398,5 +399,15 @@ public class MyPageService {
                 .collect(Collectors.toList());
     }
 
+    // 로그인한 사용자의 모든 업적 조회
+    public List<MemberAchievementResponseDTO> getAllMyStatsAchievements(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
+        List<MemberAchievement> achievements = memberAchievementRepository.findAllByMember(member);
+
+        return achievements.stream()
+                .map(MemberAchievementResponseDTO::from)
+                .toList();
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
@@ -410,4 +410,17 @@ public class MyPageService {
                 .map(MemberAchievementResponseDTO::from)
                 .toList();
     }
+
+    // 로그인한 사용자가 달성한 최신 업적 3개 조회
+    public List<MemberAchievementResponseDTO> getTop3StatsAchievements(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberAchievement> recent3Achievements = memberAchievementRepository
+                .findTop3ByMemberAndCompletedTrueOrderByCompletedAtDescUpdatedAtDesc(member);
+
+        return recent3Achievements.stream()
+                .map(MemberAchievementResponseDTO::from)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 📌 Issue Number
- #144 

## 🪐 작업 내용 - 기능 개발
- 로그인한 사용자의 모든 업적 조회 API 구현
- 로그인한 사용자가 달성한 최신 업적 3개 조회 API 구현
- 다른 사용자의 모든 업적 조회 API 구현
- 다른 사용자가 달성한 최신 업적 3개 조회 API 구현

## ✅ PR 상세 내용
- MemberAchievement 누락 시, 업적 조회 시점에 자동 생성되도록 처리
- 업적 이미지 URL은 달성 여부에 따라 컬러/흑백 자동 분기 처리
- 엔드포인트 통일 (예: /member/achievement, /member/{memberId}/achievement)

## 📚 Reference 
- X