### PR TITLE
feat: 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회 API 구현

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
@@ -164,35 +164,6 @@ public class MyPageController implements MyPageApi {
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
                 "내가 스크랩한 레시피 조회 성공", scrappedRecipes));
     }
-
-    // 로그인한 사용자의 모든 챌린지 업적 조회
-    @GetMapping("/challenge")
-    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievements(
-            @AuthenticationPrincipal MemberDetails memberDetails
-    ) {
-        Long memberId = memberDetails.getId();
-
-        List<MemberChallengeResponseDTO> achievements = myPageService.getAllAchievements(memberId);
-
-        return ResponseEntity.ok(CommonResponse.success(
-                HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                "로그인한 사용자의 모든 챌린지 업적 조회 성공", achievements));
-    }
-
-    // 로그인한 사용자의 달성한 최신 챌린지 업적 3개 조회하기
-    @GetMapping("/challenge/top3")
-    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3Achievements(
-            @AuthenticationPrincipal MemberDetails memberDetails
-    ) {
-        Long memberId = memberDetails.getId();
-
-        List<MemberChallengeResponseDTO> top3Achievements = myPageService.getTop3Achievements(memberId);
-
-        return ResponseEntity.ok(CommonResponse.success(
-                HttpStatus.OK.value(), HttpStatus.OK.toString(),
-                "로그인한 사용자가 달성한 최신 챌린지 업적 3개 조회 성공", top3Achievements));
-    }
-
     // 다른 사용자가 업로드한 모든 레시피 조회하기
     @GetMapping("/{memberId}/recipes")
     public ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getUserRecipes(
@@ -204,12 +175,40 @@ public class MyPageController implements MyPageApi {
 
     }
 
+    // 로그인한 사용자의 모든 챌린지 업적 조회
+    @GetMapping("/challenge")
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllChallengeAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        Long memberId = memberDetails.getId();
+
+        List<MemberChallengeResponseDTO> achievements = myPageService.getAllChallengeAchievements(memberId);
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "로그인한 사용자의 모든 챌린지 업적 조회 성공", achievements));
+    }
+
+    // 로그인한 사용자의 달성한 최신 챌린지 업적 3개 조회하기
+    @GetMapping("/challenge/top3")
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3ChallengeAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        Long memberId = memberDetails.getId();
+
+        List<MemberChallengeResponseDTO> top3Achievements = myPageService.getTop3ChallengeAchievements(memberId);
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "로그인한 사용자가 달성한 최신 챌린지 업적 3개 조회 성공", top3Achievements));
+    }
+
     // 다른 사용자의 모든 챌린지 업적 조회하기
     @GetMapping("/{memberId}/challenge")
-    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievementsByMemberId(
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getOtherAllChallengeAchievements(
             @PathVariable Long memberId
     ) {
-        List<MemberChallengeResponseDTO> achievements = myPageService.getAllAchievementsByMemberId(memberId);
+        List<MemberChallengeResponseDTO> achievements = myPageService.getAllChallengeAchievements(memberId);
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
                 "다른 사용자의 모든 챌린지 업적 조회 성공", achievements));
@@ -217,10 +216,10 @@ public class MyPageController implements MyPageApi {
 
     // 다른 사용자의 달성한 최신 챌린지 업적 3개 조회하기
     @GetMapping("/{memberId}/challenge/top3")
-    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3AchievementsByMemberId(
+    public ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getOtherTop3ChallengeAchievements(
             @PathVariable Long memberId
     ) {
-        List<MemberChallengeResponseDTO> achievements = myPageService.getTop3AchievementsByMemberId(memberId);
+        List<MemberChallengeResponseDTO> achievements = myPageService.getTop3ChallengeAchievements(memberId);
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
                 "다른 사용자가 달성한 최신 챌린지 업적 3개 조회 성공", achievements));

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MyPageController.java
@@ -273,4 +273,27 @@ public class MyPageController implements MyPageApi {
                 "다른 사용자가 달성한 최신 업적 3개 조회 성공", top3));
     }
 
+    // 로그인한 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회
+    @GetMapping("/all-achievement/top3")
+    public ResponseEntity<CommonResponse<List<MemberRecentAchievementDTO>>> getTop3RecentAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        List<MemberRecentAchievementDTO> result = myPageService.getTop3AllAchievements(memberDetails.getId());
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "사용자의 일반 업적 + 챌린지 업적 통합 최신 3개 조회 성공", result));
+    }
+
+    // 다른 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회
+    @GetMapping("/{memberId}/all-achievement/top3")
+    public ResponseEntity<CommonResponse<List<MemberRecentAchievementDTO>>> getTop3RecentAchievements(
+            @PathVariable Long memberId
+    ) {
+        List<MemberRecentAchievementDTO> result = myPageService.getTop3AllAchievements(memberId);
+
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "사용자의 일반 업적 + 챌린지 업적 통합 최신 3개 조회 성공", result));
+    }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
@@ -330,6 +330,41 @@ public interface MyPageApi {
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
+    // 다른 사용자가 업로드한 모든 레시피 조회하기
+    @Operation(summary = "다른 사용자가 업로드한 모든 레시피 조회하기", description = "다른 사용자가 업로드한 모든 레시피 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 사용자가 업로드한 모든 레시피 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "다른 사용자 레시피 조회 성공",
+                                      "data": [
+                                        {
+                                          "recipeId": 1,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png"
+                                        },
+                                        {
+                                          "recipeId": 2,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png"
+                                        },
+                                        .
+                                        .
+                                        .
+                                        {
+                                          "recipeId": 9,
+                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00089_1.png"
+                                        }
+                                      ]
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getUserRecipes(
+            @PathVariable("memberId") Long memberId
+    );
+
     // 로그인한 사용자의 모든 챌린지 업적 조회
     @Operation(summary = "로그인한 사용자의 모든 챌린지 업적 조회하기", description = "로그인한 사용자의 모든 챌린지 업적을 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
@@ -381,7 +416,7 @@ public interface MyPageApi {
                                      }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievements(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllChallengeAchievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
@@ -422,44 +457,10 @@ public interface MyPageApi {
                                     }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3Achievements(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3ChallengeAchievements(
             @AuthenticationPrincipal MemberDetails memberDetails
     );
 
-    // 다른 사용자가 업로드한 모든 레시피 조회하기
-    @Operation(summary = "다른 사용자가 업로드한 모든 레시피 조회하기", description = "다른 사용자가 업로드한 모든 레시피 조회합니다.",
-            security = @SecurityRequirement(name = "bearerAuth"))
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "다른 사용자가 업로드한 모든 레시피 조회 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "status": 200,
-                                      "code": "200 OK",
-                                      "message": "다른 사용자 레시피 조회 성공",
-                                      "data": [
-                                        {
-                                          "recipeId": 1,
-                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_1.png"
-                                        },
-                                        {
-                                          "recipeId": 2,
-                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00029_1.png"
-                                        },
-                                        .
-                                        .
-                                        .
-                                        {
-                                          "recipeId": 9,
-                                          "imageUrl": "http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00089_1.png"
-                                        }
-                                      ]
-                                    }
-                                    """)))
-    })
-    ResponseEntity<CommonResponse<List<RecipeImageResponseDTO>>> getUserRecipes(
-            @PathVariable("memberId") Long memberId
-    );
 
     // 다른 사용자의 모든 챌린지 업적 정보 조회하기
     @Operation(summary = "다른 사용자의 모든 챌린지 업적 조회하기", description = "다른 사용자의 모든 챌린지 업적 조회합니다.",
@@ -494,7 +495,7 @@ public interface MyPageApi {
                                     }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getAllAchievementsByMemberId(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getOtherAllChallengeAchievements(
             @PathVariable Long memberId
     );
 
@@ -535,7 +536,7 @@ public interface MyPageApi {
                                     }
                                     """)))
     })
-    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getTop3AchievementsByMemberId(
+    ResponseEntity<CommonResponse<List<MemberChallengeResponseDTO>>> getOtherTop3ChallengeAchievements(
             @PathVariable Long memberId
     );
 

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MyPageApi.java
@@ -663,4 +663,47 @@ public interface MyPageApi {
     ResponseEntity<CommonResponse<List<MemberAchievementResponseDTO>>> getTop3StatsAchievementsByMemberId(
             @PathVariable Long memberId
     );
+
+    // 로그인한 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회
+    @Operation(summary = "로그인한 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회하기", description = "로그인한 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인한 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "사용자의 일반 업적 + 챌린지 업적 통합 최신 3개 조회 성공",
+                                      "data": [
+                                       
+                                      ]
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberRecentAchievementDTO>>> getTop3RecentAchievements(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
+
+
+    // 다른 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회
+    @Operation(summary = "다른 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회하기", description = "다른 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "사용자의 일반 업적 + 챌린지 업적 통합 최신 3개 조회 성공",
+                                      "data": [
+                                        
+                                      ]
+                                    }
+                                    """)))
+    })
+    ResponseEntity<CommonResponse<List<MemberRecentAchievementDTO>>> getTop3RecentAchievements(
+            @PathVariable Long memberId
+    );
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberRecentAchievementDTO.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/dto/response/MemberRecentAchievementDTO.java
@@ -1,0 +1,15 @@
+package BE_Elixir.Elixir.domain.member.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@AllArgsConstructor
+public class MemberRecentAchievementDTO {
+    private String achievementName; // 업적 명
+    private String achievementImageUrl; // 업적 이미지
+    private boolean completed;
+    private LocalDateTime completedAt;
+}

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
@@ -233,8 +233,21 @@ public class MyPageService {
                 .toList();
     }
 
-    // 로그인한 사용자의 모든 챌린지 업적 정보 조회
-    public List<MemberChallengeResponseDTO> getAllAchievements(Long memberId) {
+    // 다른 사용자가 업로드한 모든 레시피 조회하기
+    public List<RecipeImageResponseDTO> getUserRecipes(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Recipe> recipes = recipeRepository.findAllByMember(member);
+
+        return recipes.stream()
+                .map(recipe -> new RecipeImageResponseDTO(recipe.getId(), recipe.getImageUrl()))
+                .limit(9)
+                .collect(Collectors.toList());
+    }
+
+    // 사용자의 모든 챌린지 업적 정보 조회
+    public List<MemberChallengeResponseDTO> getAllChallengeAchievements(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -272,8 +285,8 @@ public class MyPageService {
                 .collect(Collectors.toList());
     }
 
-    // 로그인한 사용자의 달성한 업적 최신 3개 조회하기
-    public List<MemberChallengeResponseDTO> getTop3Achievements(Long memberId) {
+    // 사용자가 달성한 챌린지 업적 최신 3개 조회하기
+    public List<MemberChallengeResponseDTO> getTop3ChallengeAchievements(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -316,92 +329,6 @@ public class MyPageService {
         return top3Achievements;
     }
 
-    // 다른 사용자가 업로드한 모든 레시피 조회하기
-    public List<RecipeImageResponseDTO> getUserRecipes(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        List<Recipe> recipes = recipeRepository.findAllByMember(member);
-
-        return recipes.stream()
-                .map(recipe -> new RecipeImageResponseDTO(recipe.getId(), recipe.getImageUrl()))
-                .limit(9)
-                .collect(Collectors.toList());
-    }
-
-    // 다른 사용자의 모든 챌린지 업적 정보 조회하기
-    public List<MemberChallengeResponseDTO> getAllAchievementsByMemberId(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        List<Challenge> allChallenges = challengeRepository.findAllOrderedByYearAndMonth();
-        List<ChallengeAchievement> achievements = challengeAchievementRepository.findByMemberId(member.getId());
-
-        Map<Long, ChallengeAchievement> achievementMap = achievements.stream()
-                .collect(Collectors.toMap(ChallengeAchievement::getChallengeId, a -> a));
-
-        return allChallenges.stream()
-                .map(challenge -> {
-                    ChallengeAchievement achievement = achievementMap.get(challenge.getId());
-
-                    boolean completed = (achievement != null)
-                            && achievement.isStep4Goal1Achieved()
-                            && achievement.isStep4Goal2Achieved();
-
-                    String imageUrl = completed
-                            ? challenge.getAchievementImageUrl()
-                            : challenge.getGrayAchievementImageUrl();
-
-                    return new MemberChallengeResponseDTO(
-                            challenge.getYear(),
-                            challenge.getMonth(),
-                            challenge.getAchievementName(),
-                            imageUrl,
-                            completed
-                    );
-                }).collect(Collectors.toList());
-    }
-
-    // 다른 사용자의 최신 업적 3개 조회
-    public List<MemberChallengeResponseDTO> getTop3AchievementsByMemberId(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        List<ChallengeAchievement> achievements = challengeAchievementRepository.findByMemberId(member.getId());
-
-        Set<Long> challengeIds = achievements.stream()
-                .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
-                .map(ChallengeAchievement::getChallengeId)
-                .collect(Collectors.toSet());
-
-        List<Challenge> challenges = challengeRepository.findAllById(challengeIds);
-
-        Map<Long, Challenge> challengeMap = challenges.stream()
-                .collect(Collectors.toMap(Challenge::getId, c -> c));
-
-        return achievements.stream()
-                .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
-                .sorted((a1, a2) -> {
-                    Challenge c1 = challengeMap.get(a1.getChallengeId());
-                    Challenge c2 = challengeMap.get(a2.getChallengeId());
-                    int compareYear = Integer.compare(c2.getYear(), c1.getYear());
-                    return (compareYear != 0)
-                            ? compareYear
-                            : Integer.compare(c2.getMonth(), c1.getMonth());
-                })
-                .limit(3)
-                .map(a -> {
-                    Challenge challenge = challengeMap.get(a.getChallengeId());
-                    return new MemberChallengeResponseDTO(
-                            challenge.getYear(),
-                            challenge.getMonth(),
-                            challenge.getAchievementName(),
-                            challenge.getAchievementImageUrl(),
-                            true
-                    );
-                })
-                .collect(Collectors.toList());
-    }
 
     // 사용자의 모든 업적 조회
     @Transactional

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
@@ -28,10 +28,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -375,6 +373,67 @@ public class MyPageService {
 
         return recent3Achievements.stream()
                 .map(MemberAchievementResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+
+    // 사용자가 달성한 일반 업적과 챌린지 업적 통합 최신 3개 조회
+    public List<MemberRecentAchievementDTO> getTop3AllAchievements(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberRecentAchievementDTO> tempList = new ArrayList<>();
+
+        // 달성한 일반 업적
+        List<MemberAchievement> achievements = memberAchievementRepository
+                .findTop3ByMemberAndCompletedTrueOrderByCompletedAtDescUpdatedAtDesc(member);
+
+        for (MemberAchievement a : achievements) {
+            tempList.add(new MemberRecentAchievementDTO(
+                    a.getAchievement().getAchievementName(),
+                    a.getAchievement().getAchievementImageUrl(),
+                    true,
+                    a.getCompletedAt()
+            ));
+        }
+
+        // 달성한 챌린지 업적
+        List<ChallengeAchievement> challengeAchievements = challengeAchievementRepository.findByMemberId(memberId);
+
+        Set<Long> challengeIds = challengeAchievements.stream()
+                .filter(a -> a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved())
+                .map(ChallengeAchievement::getChallengeId)
+                .collect(Collectors.toSet());
+
+        List<Challenge> challenges = challengeRepository.findAllById(challengeIds);
+
+        Map<Long, Challenge> challengeMap = challenges.stream()
+                .collect(Collectors.toMap(Challenge::getId, c -> c));
+
+        for (ChallengeAchievement a : challengeAchievements) {
+            if (a.isStep4Goal1Achieved() && a.isStep4Goal2Achieved()) {
+                Challenge challenge = challengeMap.get(a.getChallengeId());
+                LocalDateTime completedAt = LocalDateTime.of(challenge.getYear(), challenge.getMonth(), 1, 0, 0);
+
+                tempList.add(new MemberRecentAchievementDTO(
+                        challenge.getAchievementName(),
+                        challenge.getAchievementImageUrl(),
+                        true,
+                        completedAt
+                ));
+            }
+        }
+
+        // 정렬 및 3개 추출
+        return tempList.stream()
+                .sorted(Comparator.comparing(MemberRecentAchievementDTO::getCompletedAt).reversed())
+                .limit(3)
+                .map(dto -> new MemberRecentAchievementDTO(
+                        dto.getAchievementName(),
+                        dto.getAchievementImageUrl(),
+                        dto.isCompleted(),
+                        dto.getCompletedAt()
+                ))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📌 Issue Number
- #144 

## 🪐 작업 내용
- 사용자가 달성한 일반 업적과 챌린지 업적을 통합하여 최신 3개를 조회하는 API 구현
- 업적은 completedAt 기준 정렬
- 두 업적을 통합해 completedAt 기준으로 최신 3개 반환

## ✅ PR 상세 내용
- 기존 getTop3StatsAchievements, getTop3ChallengeAchievements를 통합한 서비스 메서드 작성
- DTO는 achievementName, achievementImageUrl, completed, completedAt 만 반환 
- 컨트롤러에서 /{memberId}/all-achievement/top3, /all-achievement/top3 

## 📚 Reference
- X