### PR TITLE
feat: 모든 업적명 조회 시 챌린지 외 추가된 업적명도 조회하도록 수정

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/achievement/repository/MemberAchievementRepository.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/achievement/repository/MemberAchievementRepository.java
@@ -6,11 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface MemberAchievementRepository extends JpaRepository<MemberAchievement, Long> {
     List<MemberAchievement> findAllByMember(Member member);
+
+    // id 기반 완료된 업적 조회
+    List<MemberAchievement> findByMemberIdAndCompleted(Long memberId, Boolean completed);
 
     List<MemberAchievement> findTop3ByMemberAndCompletedTrueOrderByCompletedAtDescUpdatedAtDesc(Member member);
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MyPageService.java
@@ -81,16 +81,32 @@ public class MyPageService {
 
     // 프로필 수정 시, 얻은 칭호 목록 조회
     public List<String> getTitles(Long memberId) {
-        // memberId 기반 챌린지 최종 달성 여부 조회 및
+        // memberId 기반 챌린지 최종 달성 여부 조회
         List<Long> achievedChallengeIds = challengeAchievementRepository.findByMemberId(memberId).stream()
                 .filter(ChallengeAchievement::isAllGoalsAchieved)
                 .map(ChallengeAchievement::getChallengeId)
                 .collect(Collectors.toList());
 
-        // 업적명 조회
-        return challengeRepository.findAllById(achievedChallengeIds).stream()
+        // 챌린지 업적명 조회
+        List<String> challengeAchievementNames = challengeRepository.findAllById(achievedChallengeIds).stream()
                 .map(Challenge::getAchievementName)
-                .collect(Collectors.toList());
+                .toList();
+
+        // memberId 기반 챌린지 외 업적 달성 여부 조회
+        List<Long> completedAchievementIds = memberAchievementRepository.findByMemberIdAndCompleted(memberId, true).stream()
+                .map(ma -> ma.getAchievement().getId())
+                .toList();
+
+        // 챌린지 외 업적명 조회
+        List<String> achievementNames = achievementRepository.findAllById(completedAchievementIds).stream()
+                .map(Achievement::getAchievementName)
+                .toList();
+
+        List<String> allTitles = new ArrayList<>();
+        allTitles.addAll(achievementNames);
+        allTitles.addAll(challengeAchievementNames);
+
+        return allTitles;
     }
 
     // 로그인한 사용자 프로필 수정하기


### PR DESCRIPTION
## 📌 Issue Number
- closed #73

## 🪐 작업 내용
- 업적명 조회 시 기능 수정 

## ✅ PR 상세 내용
- 모든 업적명 조회 시 챌린지 외 추가된 업적명도 조회하도록 수정

## 📚 Reference
- X