### PR TITLE
feat: 앱 접속 시 업적 및 챌린지 처리 API 분리

### DIFF
--- a/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/auth/service/AuthService.java
@@ -72,17 +72,6 @@ public class AuthService {
             redisAuthService.saveRefreshToken(email, refreshToken);
             log.info("Refresh Token Redis에 저장: email={}, token={}", email, refreshToken);
 
-            // 챌린지 및 업적 관련
-            // 로그인 성공 이벤트 발행
-            eventPublisher.publishEvent(new LoginSuccessEvent(request.getEmail()));
-
-            Member member = memberRepository.findByEmail(email)
-                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-            Long memberId = member.getId();
-            // 총 로그인 일수 증가
-            memberStatsService.increaseStat(memberId, AchievementType.TOTAL_LOGIN_DAYS, 1);
-            // 연속 로그인 일수 갱신
-            memberStatsService.increaseStat(memberId, AchievementType.CONSECUTIVE_LOGIN_DAYS, 1);
             return tokenResponse;
         } catch (BadCredentialsException e) {
             log.warn("로그인 실패 - 잘못된 비밀번호: {}", request.getEmail());

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import BE_Elixir.Elixir.domain.member.dto.request.*;
 import BE_Elixir.Elixir.domain.member.dto.response.*;
 import BE_Elixir.Elixir.domain.member.entity.Member;
 import BE_Elixir.Elixir.domain.member.entity.MemberDetails;
+import BE_Elixir.Elixir.domain.member.service.MemberAccessService;
 import BE_Elixir.Elixir.domain.member.service.MemberService;
 import BE_Elixir.Elixir.global.enums.LoginType;
 import BE_Elixir.Elixir.global.redis.RedisAuthService;
@@ -33,6 +34,7 @@ public class MemberController implements MemberApi {
     private final FollowService followService;
     private final JwtProvider jwtProvider;
     private final RedisAuthService redisAuthService;
+    private final MemberAccessService memberAccessService;
 
     // 이메일 중복 체크
     @GetMapping("/check-email")
@@ -218,5 +220,17 @@ public class MemberController implements MemberApi {
         return ResponseEntity.ok(CommonResponse.success(
                 HttpStatus.OK.value(), HttpStatus.OK.toString(),
                 "특정 사용자의 팔로워 목록 조회 성공", dto));
+    }
+
+    // 앱 접속 호출하기
+    @PostMapping("/access")
+    public ResponseEntity<CommonResponse> onAppAccess(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        memberAccessService.handleAppAccess(memberDetails.getId(), memberDetails.getUsername());
+        log.info("앱 접속 - email: {}", memberDetails.getUsername());
+        return ResponseEntity.ok(CommonResponse.success(
+                HttpStatus.OK.value(), HttpStatus.OK.toString(),
+                "앱 접속 호출 성공", null));
     }
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/controller/api/MemberApi.java
@@ -433,5 +433,25 @@ public interface MemberApi {
             @PathVariable("targetMemberId") Long targetMemberId
     );
 
+    // 앱 접속 호출하기
+    @Operation(summary = "사용자가 앱 접속 API 호출", description = "접속 API를 호출합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "접속 API 호출 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "status": 200,
+                                      "code": "200 OK",
+                                      "message": "앱 접속 호출 성공",
+                                      "data": null
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "500", description = "접속 API 호출 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    ResponseEntity<CommonResponse> onAppAccess(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    );
 
 }

--- a/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberAccessService.java
+++ b/src/main/java/BE_Elixir/Elixir/domain/member/service/MemberAccessService.java
@@ -1,0 +1,28 @@
+package BE_Elixir.Elixir.domain.member.service;
+
+import BE_Elixir.Elixir.domain.achievement.service.MemberStatsService;
+import BE_Elixir.Elixir.domain.challenge.event.events.LoginSuccessEvent;
+import BE_Elixir.Elixir.domain.member.repository.MemberRepository;
+import BE_Elixir.Elixir.global.enums.AchievementType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAccessService {
+
+    private final MemberRepository memberRepository;
+    private final MemberStatsService memberStatsService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void handleAppAccess(Long memberId, String email) {
+        // 로그인 성공 이벤트 발행
+        eventPublisher.publishEvent(new LoginSuccessEvent(email));
+
+        // 총 로그인 일수 증가
+        memberStatsService.increaseStat(memberId, AchievementType.TOTAL_LOGIN_DAYS, 1);
+        // 연속 로그인 일수 갱신
+        memberStatsService.increaseStat(memberId, AchievementType.CONSECUTIVE_LOGIN_DAYS, 1);
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number
- closed #154

## 🪐 작업 내용
- 사용자가 로그인 시 호출되던 업적, 챌린지 호출 메서드 분리

## ✅ PR 상세 내용
- 사용자가 앱에 접속할 때 업적, 챌린지 메서드를 호출하도록 API 구현

## 📚 Reference
- X